### PR TITLE
아이디, 닉네임 중복 확인 API 연동

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,16 @@
-import type { NextConfig } from "next";
+import type { NextConfig } from 'next';
+
+const API_BASE = process.env.API_BASE_URL;
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  async rewrites() {
+    return [
+      {
+        source: '/api/users/:path*',
+        destination: `${API_BASE}/api/users/:path*`,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/src/app/front/accout/login/page.tsx
+++ b/src/app/front/accout/login/page.tsx
@@ -73,12 +73,15 @@ export default function Login() {
         {/* 링크 */}
         <div className="flex items-center justify-end mt-2">
           <Link
-            href="find-id"
+            href="/front/accout/find-id"
             className="text-sm max-w-fit px-2 text-center border-r border-[#000000]"
           >
             아이디 찾기
           </Link>
-          <Link href="find-pw" className="text-sm max-w-fit px-2 text-center">
+          <Link
+            href="/front/accout/find-pw"
+            className="text-sm max-w-fit px-2 text-center"
+          >
             비밀번호 찾기
           </Link>
         </div>

--- a/src/app/front/accout/signup/page.tsx
+++ b/src/app/front/accout/signup/page.tsx
@@ -1,23 +1,37 @@
 'use client';
 
-import React, { useState } from 'react';
+import React from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import Input from '@/components/common/Input';
+import CheckableInput from '@/components/common/CheckableInput';
 import Button from '@/components/common/Button';
 import Link from 'next/link';
 
 // Zod 스키마 정의
 const SignUpSchema = z
   .object({
+    name: z.string().min(1, '이름을 입력해주세요'),
     userId: z.string().min(4, '아이디는 4자 이상이어야 합니다'),
+    userNickname: z.string().min(2, '닉네임은 2자 이상이어야 합니다'),
     email: z.string().min(5, '이메일은 필수입니다'),
     password: z
       .string()
       .min(6, '비밀번호는 최소 6자 이상이어야 합니다')
       .max(20, '비밀번호는 최대 20자까지 입력 가능합니다'),
     confirmPassword: z.string().min(1, '비밀번호 확인은 필수입니다'),
+
+    // ✅ 체크 플래그들도 스키마에 포함
+    isUserIdChecked: z.literal(true).refine((val) => val === true, {
+      message: '아이디 중복 확인을 해주세요',
+    }),
+    isNicknameChecked: z.literal(true).refine((val) => val === true, {
+      message: '닉네임 중복 확인을 해주세요',
+    }),
+    emailVerified: z.literal(true).refine((val) => val === true, {
+      message: '이메일 인증을 완료해주세요',
+    }),
   })
   .refine((data) => data.password === data.confirmPassword, {
     path: ['confirmPassword'],
@@ -32,54 +46,111 @@ export default function Signup() {
     handleSubmit,
     getValues,
     watch,
+    setValue,
     formState: { errors },
   } = useForm<SignUpFormValues>({
     resolver: zodResolver(SignUpSchema),
+    defaultValues: {
+      isUserIdChecked: true,
+      isNicknameChecked: true,
+      emailVerified: true,
+    },
   });
-
-  const [isChecking, setIsChecking] = useState(false);
-  const [isAvailable, setIsAvailable] = useState<boolean | null>(null);
-  const [checkMessage, setCheckMessage] = useState('');
 
   const password = watch('password');
   const confirmPassword = watch('confirmPassword');
   const isPasswordMatch =
     password && confirmPassword && password === confirmPassword;
 
-  const handleCheckUsername = async () => {
-    const userId = getValues('userId');
-    if (!userId) {
-      setCheckMessage('아이디를 입력해주세요.');
-      setIsAvailable(null);
-      return;
-    }
+  // 아이디 중복 확인 함수
+  // const handleCheckUsername = async () => {
+  //   const userId = getValues('userId');
 
-    setIsChecking(true);
-    setCheckMessage('');
-    try {
-      const response = await fetch(
-        `http://3.34.181.113:8080/v1/users/check-userid?userId=${userId}`
-      );
-      if (!response.ok) {
-        throw new Error('서버 응답 오류');
-      }
-      const result = await response.json();
+  //   // 아이디 미입력 시 메시지 표시 후 중단
+  //   if (!userId) {
+  //     setUserIdMessage('아이디를 입력해주세요.');
+  //     setIsUserIdAvailable(null);
+  //     return;
+  //   }
 
-      if (result.isAvailable) {
-        setIsAvailable(true);
-        setCheckMessage('사용 가능한 아이디입니다.');
-      } else {
-        setIsAvailable(false);
-        setCheckMessage('이미 사용 중인 아이디입니다.');
-      }
-    } catch (err) {
-      console.error(err);
-      setIsAvailable(null);
-      setCheckMessage('중복 확인 중 오류가 발생했습니다.');
-    } finally {
-      setIsChecking(false);
-    }
-  };
+  //   // 확인 중 상태로 전환
+  //   setIsCheckingUserId(true);
+  //   setUserIdMessage('');
+
+  //   try {
+  //     const response = await fetch(
+  //       `/api/users/check-userId?userId=${userId}`
+  //     );
+  //     // 응답 실패 시 에러 표시시
+  //     if (!response.ok) {
+  //       throw new Error('서버 응답 오류');
+  //     }
+
+  //     // 응답 결과 파싱
+  //     const result = await response.json();
+  //     console.log('중복확인 응답:', result);
+
+  //     // 결과에 따라 메시지 및 상태 설정
+  //     if (result === true) { // 중복 X(사용 가능)
+  //       setIsUserIdAvailable(true);
+  //       setUserIdMessage('사용 가능한 아이디입니다.');
+  //     } else { // 중복 O(사용 불불가능)
+  //       setIsUserIdAvailable(false);
+  //       setUserIdMessage('이미 사용 중인 아이디입니다.');
+  //     }
+  //   } catch (err) {
+  //     // 네트워크 또는 서버 에러 발생 시
+  //     console.error(err);
+  //     setIsUserIdAvailable(null);
+  //     setUserIdMessage('중복 확인 중 오류가 발생했습니다.');
+  //   } finally {
+  //     setIsCheckingUserId(false);
+  //   }
+  // };
+
+  // 닉네임 중복 확인 함수
+  // const handleCheckNickname = async () => {
+  //   const userNickname = getValues('userNickname');
+
+  //   // 닉네임임 미입력 시 메시지 표시 후 중단
+  //   if (!userNickname) {
+  //     setNicknameMessage('닉네임을 입력해주세요.');
+  //     setIsNicknameAvailable(null);
+  //     return;
+  //   }
+
+  //   // 확인 중 상태로 전환
+  //   setIsCheckingNickname(true);
+  //   setNicknameMessage('');
+
+  //   try {
+  //     const response = await fetch(
+  //       `/api/users/check-nickname?nickname=${userNickname}`
+  //     );
+  //     // 응답 실패 시 에러 표시시
+  //     if (!response.ok) {
+  //       throw new Error('서버 응답 오류');
+  //     }
+
+  //     // 응답 결과 파싱
+  //     const result = await response.json();
+
+  //     // 결과에 따라 메시지 및 상태 설정
+  //     if (result === true) {
+  //       setIsNicknameAvailable(true);
+  //       setNicknameMessage('사용 가능한 닉네임입니다.');
+  //     } else {
+  //       setIsNicknameAvailable(false);
+  //       setNicknameMessage('이미 사용 중인 닉네임입니다.');
+  //     }
+  //   } catch (err) {
+  //     console.error(err);
+  //     setIsNicknameAvailable(null);
+  //     setNicknameMessage('중복 확인 중 오류가 발생했습니다.');
+  //   } finally {
+  //     setIsCheckingNickname(false);
+  //   }
+  // };
 
   // 회원가입 처리 로직
   const onSubmit = (data: SignUpFormValues) => {
@@ -92,36 +163,33 @@ export default function Signup() {
       <form onSubmit={handleSubmit(onSubmit)}>
         {/* 이름 입력 (선택) */}
         <div className="relative mb-6">
-          <Input type="text" placeholder="이름을 입력하세요" />
+          <Input
+            type="text"
+            placeholder="이름을 입력하세요"
+            {...register('name')}
+          />
+          <p
+            className={`absolute top-[38px] left-0 mt-1 px-2 text-xs text-red-500 transition-opacity duration-200 ${
+              errors.name ? 'opacity-100' : 'opacity-0'
+            }`}
+          >
+            {errors.name?.message ?? ''}
+          </p>
         </div>
 
         {/* 아이디 입력 - 중복 확인 api */}
-        <div className="relative mb-6">
-          <div className="flex flex-btn items-center justify-center gap-1.5">
-            <Input type="text" placeholder="아이디를 입력하세요" />
-            <button
-              type="button"
-              onClick={handleCheckUsername}
-              className="px-3 py-2 bg-gray-200 rounded-md text-sm"
-              disabled={isChecking}
-            >
-              {isChecking ? '확인 중...' : '중복 확인'}
-            </button>
-          </div>
-          {checkMessage && (
-            <p
-              className={`absolute top-[38px] left-0 mt-1 text-xs text-red-500 transition-opacity duration-200 mt-1 text-xs ${
-                isAvailable === true
-                  ? 'main-color'
-                  : isAvailable === false
-                    ? 'point2-color'
-                    : 'point2-color'
-              }`}
-            >
-              {checkMessage}
-            </p>
-          )}
-        </div>
+        <CheckableInput<SignUpFormValues>
+          name="userId"
+          placeholder="아이디를 입력하세요"
+          checkUrl="/api/users/check-userId"
+          queryKey="userId"
+          successMessage="사용 가능한 아이디입니다."
+          failureMessage="이미 사용 중인 아이디입니다."
+          register={register}
+          getValues={getValues}
+          setValue={setValue}
+          flagField="isUserIdChecked"
+        />
 
         {/* 비밀번호 입력 */}
         <div className="relative mb-6">
@@ -131,7 +199,7 @@ export default function Signup() {
             {...register('password')}
           />
           <p
-            className={`absolute top-[38px] left-0 mt-1 text-xs text-red-500 transition-opacity duration-200 ${
+            className={`absolute top-[38px] left-0 mt-1 px-2 text-xs text-red-500 transition-opacity duration-200 ${
               errors.password ? 'opacity-100' : 'opacity-0'
             }`}
           >
@@ -148,13 +216,13 @@ export default function Signup() {
           />
           {/* 오류 메시지 */}
           {errors.confirmPassword && (
-            <p className="absolute top-[38px] left-0 mt-1 text-xs text-red-500 transition-opacity duration-200 opacity-100">
+            <p className="absolute top-[38px] left-0 mt-1 px-2 text-xs text-red-500 transition-opacity duration-200 opacity-100">
               {errors.confirmPassword.message}
             </p>
           )}
           {/* 성공 메시지 */}
           {!errors.confirmPassword && isPasswordMatch && (
-            <p className="absolute top-[38px] left-0 mt-1 text-xs main-color transition-opacity duration-200 opacity-100">
+            <p className="absolute top-[38px] left-0 mt-1 px-2 text-xs main-color transition-opacity duration-200 opacity-100">
               비밀번호가 일치합니다
             </p>
           )}
@@ -168,35 +236,30 @@ export default function Signup() {
               type="button"
               // onClick={handleCheckUsername}
               className="px-3 py-2 bg-gray-200 rounded-md text-sm"
-              disabled={isChecking}
+              // disabled={isChecking}
             >
               인증 번호 발송
             </button>
           </div>
           <Input type="text" placeholder="인증번호를 입력하세요" />
           <p
-            className={`absolute top-[38px] left-0 mt-1 text-xs text-red-500 transition-opacity duration-200`}
+            className={`absolute top-[38px] left-0 mt-1 px-2 text-xs text-red-500 transition-opacity duration-200`}
           ></p>
         </div>
 
         {/* 닉네임 입력 */}
-        <div className="relative mb-6">
-          <div className="flex flex-btn items-center justify-center gap-1.5">
-            <Input type="text" placeholder="닉네임을 입력하세요" />
-            <button
-              type="button"
-              // onClick={handleCheckUsername}
-              className="px-3 py-2 bg-gray-200 rounded-md text-sm"
-              disabled={isChecking}
-            >
-              {isChecking ? '확인 중...' : '중복 확인'}
-            </button>
-          </div>
-
-          <p
-            className={`absolute top-[38px] left-0 mt-1 text-xs text-red-500 transition-opacity duration-200`}
-          ></p>
-        </div>
+        <CheckableInput<SignUpFormValues>
+          name="userNickname"
+          placeholder="닉네임을 입력하세요"
+          checkUrl="/api/users/check-nickname"
+          queryKey="nickname"
+          successMessage="사용 가능한 닉네임입니다."
+          failureMessage="이미 사용 중인 닉네임입니다."
+          register={register}
+          getValues={getValues}
+          setValue={setValue}
+          flagField="isNicknameChecked"
+        />
 
         {/* 취소 버튼 / 회원가입 */}
         <div className="flex items-center justify-center gap-1.5 mt-10">

--- a/src/app/front/accout/signup/page.tsx
+++ b/src/app/front/accout/signup/page.tsx
@@ -201,7 +201,7 @@ export default function Signup() {
         {/* 취소 버튼 / 회원가입 */}
         <div className="flex items-center justify-center gap-1.5 mt-10">
           <Link
-            href="login"
+            href="/front/accout/login"
             className="flex-1 bg-main-color text-white px-4 py-3 rounded-md w-full text-center"
           >
             취소

--- a/src/app/front/intro/page.tsx
+++ b/src/app/front/intro/page.tsx
@@ -13,7 +13,7 @@ export default function Intro() {
         친구들과 소통하고 그룹으로 추억을 쌓아보세요!
       </p>
       <Link
-        href="front/accout/login"
+        href="/front/accout/login"
         className="bg-main-color text-white px-4 py-3 rounded w-full text-center mt-20 inline-block animate-slideUp delay-1200 opacity-0"
       >
         지금 시작하기

--- a/src/components/common/CheckableInput.tsx
+++ b/src/components/common/CheckableInput.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { useState } from 'react';
+import Input from '@/components/common/Input';
+import {
+  UseFormRegister,
+  UseFormGetValues,
+  UseFormSetValue,
+  FieldValues,
+  Path,
+  PathValue,
+} from 'react-hook-form';
+
+type Props<T extends FieldValues> = {
+  name: Path<T>;
+  placeholder: string;
+  checkUrl: string;
+  queryKey: string;
+  successMessage: string;
+  failureMessage: string;
+  register: UseFormRegister<T>;
+  getValues: UseFormGetValues<T>;
+  setValue: UseFormSetValue<T>;
+  flagField: Path<T>;
+};
+
+export default function CheckableInput<T extends FieldValues>({
+  name,
+  placeholder,
+  checkUrl,
+  queryKey,
+  successMessage,
+  failureMessage,
+  register,
+  getValues,
+  setValue,
+  flagField,
+}: Props<T>) {
+  const [isChecking, setIsChecking] = useState(false);
+  const [isAvailable, setIsAvailable] = useState<boolean | null>(null);
+  const [message, setMessage] = useState('');
+
+  const handleCheck = async () => {
+    const value = getValues(name as Path<T>);
+
+    if (!value) {
+      setMessage('입력값을 작성해주세요.');
+      setIsAvailable(null);
+      return;
+    }
+
+    setIsChecking(true);
+    setMessage('');
+
+    try {
+      const response = await fetch(`${checkUrl}?${queryKey}=${value}`);
+      if (!response.ok) throw new Error('서버 오류');
+      const result = await response.json();
+
+      if (result === true) {
+        setIsAvailable(true);
+        setMessage(successMessage);
+        setValue(flagField, true as PathValue<T, Path<T>>);
+      } else {
+        setIsAvailable(false);
+        setMessage(failureMessage);
+        setValue(flagField, true as PathValue<T, Path<T>>);
+      }
+    } catch (err) {
+      console.error(err);
+      setIsAvailable(null);
+      setMessage('중복 확인 중 오류가 발생했습니다.');
+    } finally {
+      setIsChecking(false);
+    }
+  };
+
+  return (
+    <div className="relative mb-6">
+      <div className="flex flex-btn items-center justify-center gap-1.5">
+        <Input
+          type="text"
+          placeholder={placeholder}
+          {...register(name as Path<T>)}
+          className="flex-1 px-3 py-2 border rounded-md"
+        />
+        <button
+          type="button"
+          onClick={handleCheck}
+          disabled={isChecking}
+          className="px-3 py-2 bg-gray-200 rounded-md text-sm"
+        >
+          {/* {isChecking ? '확인 중...' : '중복 확인'} */}
+          중복 확인
+        </button>
+      </div>
+      {message && (
+        <p
+          className={`absolute top-[38px] left-0 mt-1 px-2 text-xs transition-opacity duration-200 ${
+            isAvailable === true
+              ? 'main-color'
+              : isAvailable === false
+                ? 'text-red-500'
+                : ''
+          }`}
+        >
+          {message}
+        </p>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolves: https://github.com/DdNnTt/Chingu-Frontend/issues/35

## 📝작업 내용
- 아이디 입력 값에 대한 중복 확인 API 연동 및 응답 결과에 따른 메시지 처리
- 닉네임 입력 값에 대한 중복 확인 API 연동 및 검증 결과 상태 반영

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
