### PR TITLE
로그인 API 연동

### DIFF
--- a/src/app/api/auth/email/verify/route.ts
+++ b/src/app/api/auth/email/verify/route.ts
@@ -1,24 +1,34 @@
-// /app/api/auth/email/verify/route.ts
 import { NextRequest, NextResponse } from 'next/server';
 
 const API_BASE = process.env.API_BASE_URL;
 
 export async function POST(req: NextRequest) {
   const email = req.nextUrl.searchParams.get('email');
-  if (!email)
+  if (!email) {
     return NextResponse.json({ error: '이메일 누락' }, { status: 400 });
+  }
 
-  const res = await fetch(
-    `${API_BASE}/api/auth/email/verify?email=${encodeURIComponent(email)}`,
-    {
-      method: 'POST',
-      credentials: 'include', // 중요
+  try {
+    const response = await fetch(
+      `${API_BASE}/api/auth/email/verify?email=${encodeURIComponent(email)}`,
+      {
+        method: 'POST',
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      }
+    );
+
+    // res.text() 대신 response.body를 그대로 전달
+    return new NextResponse(response.body, {
+      status: response.status,
       headers: {
-        'Content-Type': 'application/json',
+        'Content-Type': response.headers.get('content-type') || 'text/plain',
       },
-    }
-  );
-
-  const data = await res.text();
-  return new NextResponse(data, { status: res.status });
+    });
+  } catch (error) {
+    console.error('[프록시 오류]', error);
+    return NextResponse.json({ error: '프록시 실패' }, { status: 500 });
+  }
 }

--- a/src/app/api/auth/login/route.ts
+++ b/src/app/api/auth/login/route.ts
@@ -1,0 +1,58 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest) {
+  const API_BASE = process.env.API_BASE_URL;
+
+  if (!API_BASE) {
+    console.error('[환경변수 오류] API_BASE_URL이 설정되지 않았습니다.');
+    return NextResponse.json(
+      { message: 'API 주소가 설정되지 않았습니다.' },
+      { status: 500 }
+    );
+  }
+
+  try {
+    const body = await req.json();
+
+    const backendRes = await fetch(`${API_BASE}/auth/login`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+
+    const contentType = backendRes.headers.get('content-type');
+
+    if (!backendRes.ok) {
+      const errorBody = await backendRes.text();
+      console.error('[백엔드 로그인 에러]', backendRes.status, errorBody);
+      return new NextResponse(errorBody, {
+        status: backendRes.status,
+        headers: {
+          'Content-Type': contentType ?? 'text/plain',
+        },
+      });
+    }
+
+    const data = contentType?.includes('application/json')
+      ? await backendRes.json()
+      : await backendRes.text();
+
+    return new NextResponse(
+      contentType?.includes('application/json') ? JSON.stringify(data) : data,
+      {
+        status: backendRes.status,
+        headers: {
+          'Content-Type': contentType ?? 'text/plain',
+        },
+      }
+    );
+  } catch (err) {
+    console.error('[프록시 로그인 오류]', err);
+    return NextResponse.json(
+      { message: '서버 프록시 오류 발생' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/proxy/signup/route.ts
+++ b/src/app/api/proxy/signup/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(req: Request) {
+  const API_BASE = process.env.API_BASE_URL;
+
+  if (!API_BASE) {
+    console.error('[환경변수 오류] API_BASE_URL이 설정되지 않았습니다.');
+    return NextResponse.json(
+      { message: 'API 주소가 설정되지 않았습니다.' },
+      { status: 500 }
+    );
+  }
+
+  try {
+    const body = await req.json();
+
+    const backendRes = await fetch(`${API_BASE}/api/users/signup`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+
+    const contentType = backendRes.headers.get('content-type');
+    const data = contentType?.includes('application/json')
+      ? await backendRes.json()
+      : await backendRes.text();
+
+    return new NextResponse(
+      contentType?.includes('application/json') ? JSON.stringify(data) : data,
+      {
+        status: backendRes.status,
+        headers: { 'Content-Type': contentType ?? 'text/plain' },
+      }
+    );
+  } catch (err) {
+    console.error('[프록시 오류]', err);
+    return NextResponse.json(
+      { message: '서버 프록시 오류 발생' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/users/check-nickname/route.ts
+++ b/src/app/api/users/check-nickname/route.ts
@@ -1,23 +1,66 @@
-// /app/api/users/check-nickname/route.ts
-import { NextRequest, NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
 
-const API_BASE = process.env.API_BASE_URL; // 예: http://3.34.181.113:8080
+export const runtime = 'nodejs';
 
-export async function GET(req: NextRequest) {
-  const nickname = req.nextUrl.searchParams.get('nickname');
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const nickname = searchParams.get('nickname');
+  const API_BASE = process.env.API_BASE_URL;
+
+  const cookieStore = await cookies();
+  const token = cookieStore.get('accessToken')?.value;
+
   if (!nickname) {
-    return NextResponse.json({ error: '닉네임 누락' }, { status: 400 });
+    return NextResponse.json({ error: '닉네임이 없습니다' }, { status: 400 });
+  }
+
+  if (!API_BASE) {
+    return NextResponse.json({ error: 'API 주소가 없습니다' }, { status: 500 });
   }
 
   try {
-    const res = await fetch(
-      `${API_BASE}/api/users/check-nickname?nickname=${encodeURIComponent(nickname)}`
-    );
-    const result = await res.json();
+    const url = `${API_BASE}/api/users/check-nickname?nickname=${encodeURIComponent(nickname)}`;
+    console.log('[닉네임 중복 확인 요청]', decodeURIComponent(url));
 
-    return NextResponse.json(result, { status: 200 });
-  } catch (error) {
-    console.error(error);
-    return NextResponse.json({ error: '서버 오류' }, { status: 500 });
+    const res = await fetch(url, {
+      method: 'GET',
+      headers: {
+        Accept: 'application/json',
+        ...(token && { Authorization: `Bearer ${token}` }),
+      },
+    });
+
+    const text = await res.text();
+
+    if (!res.ok) {
+      throw new Error(`백엔드 응답 오류: ${res.status} ${text}`);
+    }
+
+    // 응답 본문 파싱
+    let result;
+    if (text === 'true') {
+      result = true; // 문자열 true → boolean true
+    } else if (text === 'false') {
+      result = false; // 문자열 false → boolean false
+    } else {
+      try {
+        // JSON 형식인 경우 파싱 시도
+        result = JSON.parse(text);
+      } catch (jsonErr) {
+        // 파싱 실패 시 로그 출력 후 예외 발생
+        console.error('[jsonErr]', jsonErr);
+        throw new Error(`JSON 파싱 실패: ${text}`);
+      }
+    }
+    // 최종적으로 클라이언트에 JSON 응답 반환
+    return NextResponse.json(result);
+  } catch (e) {
+    // 전체 try 블록 실패 시 에러 로그와 함께 500 응답 반환
+    console.error('[닉네임 중복 확인 에러]', e);
+    return NextResponse.json(
+      { error: '중복 확인 중 오류 발생' },
+      { status: 500 }
+    );
   }
 }

--- a/src/app/front/accout/login/page.tsx
+++ b/src/app/front/accout/login/page.tsx
@@ -1,12 +1,14 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import Input from '@/components/common/Input';
 import Button from '@/components/common/Button';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import axios from 'axios';
 
 // Zod 스키마 정의
 const LoginSchema = z.object({
@@ -29,13 +31,73 @@ export default function Login() {
   });
 
   // 로그인 처리 로직
-  const onSubmit = (data: LoginFormValues) => {
-    console.log(data); // { id: '...', password: '...' }
+  const router = useRouter();
+  const [loginError, setLoginError] = useState('');
+  const [showAlert, setShowAlert] = useState(false);
+  const [hideAlert, setHideAlert] = useState(false);
+
+  useEffect(() => {
+    if (loginError) {
+      setShowAlert(true);
+      setHideAlert(false);
+
+      const hideTimer = setTimeout(() => {
+        setHideAlert(true); // opacity 줄이기 시작
+      }, 1000); // 1초 뒤에 사라지게 전환
+
+      const removeTimer = setTimeout(() => {
+        setShowAlert(false); // DOM 제거
+      }, 1500); // fade-out 완료 후 제거
+
+      return () => {
+        clearTimeout(hideTimer);
+        clearTimeout(removeTimer);
+      };
+    }
+  }, [loginError]);
+
+  const onSubmit = async (data: LoginFormValues) => {
+    try {
+      const response = await axios.post('/api/auth/login', {
+        userId: data.id,
+        password: data.password,
+      });
+
+      const { accessToken, tokenType } = response.data;
+
+      localStorage.setItem('accessToken', accessToken);
+      localStorage.setItem('tokenType', tokenType);
+
+      router.push('/front/my-home');
+    } catch (error: unknown) {
+      if (axios.isAxiosError(error)) {
+        const message = error.response?.data?.message;
+
+        if (message === 'Bad credentials') {
+          setShowAlert(false);
+          setLoginError('');
+          setTimeout(() => {
+            setLoginError('아이디 또는 비밀번호를 확인해주세요.');
+          }, 10);
+        } else {
+          setLoginError('서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.');
+        }
+      } else {
+        setLoginError('알 수 없는 오류가 발생했습니다.');
+      }
+    }
   };
 
   return (
     <div className="login-page py-4 px-4 mt-20">
       <h2 className="text-2xl font-semibold mb-14 text-center">로그인</h2>
+
+      {/* 알럿 메시지 */}
+      {showAlert && (
+        <div className={`cont-alert ${hideAlert ? 'hide' : ''}`}>
+          {loginError}
+        </div>
+      )}
 
       <form onSubmit={handleSubmit(onSubmit)}>
         {/* 아이디 입력 */}

--- a/src/app/front/accout/signup/page.tsx
+++ b/src/app/front/accout/signup/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -50,9 +50,10 @@ export default function Signup() {
     getValues,
     watch,
     setValue,
-    formState: { errors },
+    formState: { errors, isSubmitted },
   } = useForm<SignUpFormValues>({
     resolver: zodResolver(SignUpSchema),
+    mode: 'onChange',
     defaultValues: {
       isUserIdChecked: true,
       isNicknameChecked: true,
@@ -60,19 +61,96 @@ export default function Signup() {
     },
   });
 
+  const name = watch('name');
   const password = watch('password');
   const confirmPassword = watch('confirmPassword');
   const isPasswordMatch =
     password && confirmPassword && password === confirmPassword;
 
   // 회원가입 처리 로직
-  const onSubmit = (data: SignUpFormValues) => {
-    console.log(data);
+  const onSubmit = async (data: SignUpFormValues) => {
+    try {
+      const payload = {
+        userId: data.userId.trim(),
+        name: data.name.trim(),
+        nickname: data.userNickname.trim(),
+        email: data.email.trim(),
+        password: data.password,
+        profilePictureUrl: '',
+        bio: '',
+      };
+
+      const res = await fetch('/api/proxy/signup', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      });
+
+      const contentType = res.headers.get('content-type');
+      const isJson = contentType?.includes('application/json');
+      const result = isJson ? await res.json() : await res.text();
+
+      if (!res.ok) {
+        console.error('[회원가입 실패]', result);
+
+        if (typeof result === 'string') {
+          alert(`회원가입 실패: ${result}`);
+        } else if (result.message?.includes('Duplicate entry')) {
+          alert('이미 사용 중인 이메일 또는 아이디입니다.');
+        } else {
+          alert(`회원가입 실패: ${result.message}`);
+        }
+
+        return;
+      }
+
+      alert('회원가입이 완료되었습니다!');
+      // router.push('/front/accout/login');
+    } catch (error) {
+      console.error('[회원가입 요청 오류]', error);
+      alert('서버 오류가 발생했습니다.');
+    }
   };
+
+  // 배너 상태 (아무것도 기입하지 않고 회원가입 버튼 클릭 시)
+  const [showErrorBanner, setShowErrorBanner] = useState(false);
+  const [hideBanner, setHideBanner] = useState(false);
+
+  useEffect(() => {
+    if (Object.keys(errors).length > 0 && isSubmitted) {
+      setShowErrorBanner(true);
+      setHideBanner(false); // 처음엔 보여야 하므로 false
+
+      const hideTimer = setTimeout(() => {
+        setHideBanner(true); // 300ms 후 서서히 사라지기 시작
+      }, 1000);
+
+      const removeTimer = setTimeout(() => {
+        setShowErrorBanner(false); // 500ms 후 DOM에서 제거
+      }, 1500);
+
+      return () => {
+        clearTimeout(hideTimer);
+        clearTimeout(removeTimer);
+      };
+    }
+  }, [errors, isSubmitted]);
 
   return (
     <div className="signup-page py-4 px-4 mt-20">
       <h2 className="text-2xl font-semibold mb-14 text-center">회원가입</h2>
+
+      {/* 알럿 배너 */}
+      {showErrorBanner && (
+        <div
+          className={`cont-alert ${hideBanner ? 'hide' : ''} text-sm text-center mb-6`}
+        >
+          모든 필수 정보를 입력해주세요.
+        </div>
+      )}
+
       <form onSubmit={handleSubmit(onSubmit)}>
         {/* 이름 입력 (선택) */}
         <div className="relative mb-6">
@@ -81,13 +159,15 @@ export default function Signup() {
             placeholder="이름을 입력하세요"
             {...register('name')}
           />
-          <p
-            className={`absolute top-[38px] left-0 mt-1 px-2 text-xs text-red-500 transition-opacity duration-200 ${
-              errors.name ? 'opacity-100' : 'opacity-0'
-            }`}
-          >
-            {errors.name?.message ?? ''}
-          </p>
+          {errors.name?.message ? (
+            <p className="absolute top-[38px] left-0 mt-1 px-2 text-xs text-red-500">
+              {errors.name.message}
+            </p>
+          ) : typeof name === 'string' && name.trim().length > 0 ? (
+            <p className="absolute top-[38px] left-0 mt-1 px-2 text-xs main-color">
+              이름이 확인되었습니다.
+            </p>
+          ) : null}
         </div>
 
         {/* 아이디 입력 - 중복 확인 api */}
@@ -111,13 +191,17 @@ export default function Signup() {
             placeholder="비밀번호를 입력하세요"
             {...register('password')}
           />
-          <p
-            className={`absolute top-[38px] left-0 mt-1 px-2 text-xs text-red-500 transition-opacity duration-200 ${
-              errors.password ? 'opacity-100' : 'opacity-0'
-            }`}
-          >
-            {errors.password?.message ?? ''}
-          </p>
+          {/* 오류 메시지 */}
+          {errors.password ? (
+            <p className="absolute top-[38px] left-0 mt-1 px-2 text-xs text-red-500 transition-opacity duration-200 opacity-100">
+              {errors.password.message}
+            </p>
+          ) : password?.length >= 6 ? (
+            // 성공 메시지
+            <p className="absolute top-[38px] left-0 mt-1 px-2 text-xs main-color transition-opacity duration-200 opacity-100">
+              사용 가능한 비밀번호입니다
+            </p>
+          ) : null}
         </div>
 
         {/* 비밀번호 확인 입력 */}

--- a/src/components/common/CheckableInput.tsx
+++ b/src/components/common/CheckableInput.tsx
@@ -41,7 +41,7 @@ export default function CheckableInput<T extends FieldValues>({
   const [message, setMessage] = useState('');
 
   const handleCheck = async () => {
-    const value = getValues(name as Path<T>);
+    const value = getValues(name as Path<T>).trim();
 
     if (!value) {
       setMessage('입력값을 작성해주세요.');
@@ -49,13 +49,20 @@ export default function CheckableInput<T extends FieldValues>({
       return;
     }
 
+    console.log('중복 확인 요청 URL:', `${checkUrl}?${queryKey}=${value}`);
+
     setIsChecking(true);
     setMessage('');
 
     try {
-      const response = await fetch(`${checkUrl}?${queryKey}=${value}`);
-      if (!response.ok) throw new Error('서버 오류');
+      const response = await fetch(
+        `${checkUrl}?${queryKey}=${encodeURIComponent(value)}`
+      );
       const result = await response.json();
+
+      if (!response.ok) {
+        throw new Error(`서버 오류: ${response.status}`);
+      }
 
       if (result === true) {
         setIsAvailable(true);
@@ -64,10 +71,10 @@ export default function CheckableInput<T extends FieldValues>({
       } else {
         setIsAvailable(false);
         setMessage(failureMessage);
-        setValue(flagField, true as PathValue<T, Path<T>>);
+        setValue(flagField, false as PathValue<T, Path<T>>);
       }
     } catch (err) {
-      console.error(err);
+      console.error('중복 확인 에러:', err);
       setIsAvailable(null);
       setMessage('중복 확인 중 오류가 발생했습니다.');
     } finally {

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -1,20 +1,24 @@
-import React, { InputHTMLAttributes } from 'react';
+import React, { InputHTMLAttributes, useId } from 'react';
 
 interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   label?: string;
 }
 
-const Input: React.FC<InputProps> = ({ label, className, ...props }) => {
+const Input: React.FC<InputProps> = ({ label, className = '', ...props }) => {
+  const generatedId = useId(); // React 18 이상에서 고유 ID 생성
+
   return (
     <div className="mb-4">
-      <label
-        htmlFor={label}
-        className="block text-sm font-medium text-gray-700"
-      >
-        {label}
-      </label>
+      {label && (
+        <label
+          htmlFor={generatedId}
+          className="block text-sm font-medium text-gray-700"
+        >
+          {label}
+        </label>
+      )}
       <input
-        id={label}
+        id={generatedId}
         className={`mt-1 block w-full px-3 py-2 border bg-[#f3f3f5] rounded-md shadow-sm focus:outline-none focus:ring-1 focus:ring-indigo-300 ${className}`}
         {...props}
       />

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2,8 +2,28 @@
 @tailwind components;
 @tailwind utilities;
 
-
-
+/* ============================================
+  Common Style
+============================================ */
+.cont-alert {
+  position: fixed;
+  top: 40%;
+  left: 50%;
+  transform: translateX(-50%);
+  color: white;
+  font-weight: 600;
+  white-space: nowrap;
+  padding: 24px 40px;
+  border-radius: 16px;
+  background: #6845f5;
+  box-shadow: 0 7px 15px 0px rgba(0, 0, 0, 0.2);
+  z-index: 10;
+  opacity: 1;
+  transition: opacity 0.5s ease-in-out;
+}
+.cont-alert.hide {
+  opacity: 0;
+}
 
 /* ============================================
   Animation
@@ -45,36 +65,33 @@
   }
 }
 
-
 /* ============================================
   Point Colors
 ============================================ */
 .main-color {
-  color: #6845F5;
+  color: #6845f5;
 }
 .bg-main-color {
-  background-color: #6845F5;
+  background-color: #6845f5;
 }
 .sub-color {
-  color: #AA96FC;
+  color: #aa96fc;
 }
 .bg-sub-color {
-  background-color: #AA96FC;
+  background-color: #aa96fc;
 }
 .point1-color {
-  color: #F6D094;
+  color: #f6d094;
 }
 .bg-point1-color {
-  background-color: #F6D094;
+  background-color: #f6d094;
 }
 .point2-color {
-  color: #F5B2B2;
+  color: #f5b2b2;
 }
 .bg-point2-color {
-  background-color: #F5B2B2;
+  background-color: #f5b2b2;
 }
-
-
 
 /* ============================================
   Style Reset
@@ -85,7 +102,8 @@
   box-sizing: border-box;
   scroll-behavior: smooth;
 }
-html, body {
+html,
+body {
   height: 100%;
   font-size: 14px;
   font-family: 'Roboto', sans-serif, 'Hakgyo-Black', 'Hakgyo-Outline';
@@ -105,7 +123,8 @@ body {
   border-radius: 20px;
   box-shadow: 3px 3px 15px #00000026;
 }
-main, main > div {
+main,
+main > div {
   height: 100%;
   border-radius: 20px;
 }
@@ -113,7 +132,6 @@ a {
   text-decoration: none;
   color: inherit;
 }
-
 
 /* ============================================
   Point Fonts

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -16,6 +16,7 @@
   padding: 24px 40px;
   border-radius: 16px;
   background: #6845f5;
+  border: 1px solid rgb(255 255 255 / 50%);
   box-shadow: 0 7px 15px 0px rgba(0, 0, 0, 0.2);
   z-index: 10;
   opacity: 1;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,6 @@
       "@/admin/*": ["./src/app/admin/*"]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts", "next.config.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolves: https://github.com/DdNnTt/Chingu-Frontend/issues/45

## 📝작업 내용
- 로그인 API (/api/auth/login) 연동 및 응답 처리
- 인증 실패(Bad credentials) 시 사용자에게 오류 메시지 알림
- 로그인 성공 시 accessToken, tokenType을 localStorage에 저장
- 로그인 성공 시 특정 페이지로 이동 (/front/my-home)
- 알럿 메시지를 통한 로그인 오류 사용자 알림 처리
- 백엔드 로그인 에러 (500 / 인증 실패) 발생 시 사용자 피드백 제공

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
