### PR TITLE
로그인 토큰 저장 방식 변경

### DIFF
--- a/src/app/front/account/login/page.tsx
+++ b/src/app/front/account/login/page.tsx
@@ -37,14 +37,15 @@ export default function Login() {
   const [hideAlert, setHideAlert] = useState(false);
   const [isLoggingIn, setIsLoggingIn] = useState(false);
 
+  // 쿠키 값 읽는 함수
+  const getCookieValue = (name: string) => {
+    const match = document.cookie.match(new RegExp(`(^| )${name}=([^;]+)`));
+    return match ? decodeURIComponent(match[2]) : null;
+  };
+
   // 로그인 상태 체크 및 토큰 콘솔 출력
   useEffect(() => {
-    const getCookieValue = (name: string) => {
-      const match = document.cookie.match(new RegExp(`(^| )${name}=([^;]+)`));
-      return match ? decodeURIComponent(match[2]) : null;
-    };
-
-    const token = getCookieValue('accessToken'); // 쿠키에서 accessToken 가져오기
+    const token = getCookieValue('accessToken');
     if (token && !hasAlerted.current) {
       try {
         const payload = JSON.parse(atob(token.split('.')[1]));
@@ -98,7 +99,10 @@ export default function Login() {
 
       const { accessToken, tokenType, nickname } = response.data;
 
-      localStorage.setItem('accessToken', accessToken);
+      // 쿠키로 저장 (secure, SameSite는 필요 시 조정)
+      document.cookie = `accessToken=${accessToken}; path=/; secure; SameSite=Lax`;
+
+      // localStorage.setItem('accessToken', accessToken);
       localStorage.setItem('tokenType', tokenType);
       localStorage.setItem('nickname', nickname);
 
@@ -130,14 +134,14 @@ export default function Login() {
   // 로그인 후 진입
   const hasAlerted = useRef(false);
 
-  useEffect(() => {
-    const token = localStorage.getItem('accessToken');
-    if (token && !hasAlerted.current) {
-      alert('이미 로그인된 상태입니다.');
-      hasAlerted.current = true;
-      router.replace('/front/my-home');
-    }
-  }, []);
+  // useEffect(() => {
+  //   const token = localStorage.getItem('accessToken');
+  //   if (token && !hasAlerted.current) {
+  //     alert('이미 로그인된 상태입니다.');
+  //     hasAlerted.current = true;
+  //     router.replace('/front/my-home');
+  //   }
+  // }, []);
 
   return (
     <div className="login-page py-4 px-4 mt-20">

--- a/src/app/front/components/layout/Header/page.tsx
+++ b/src/app/front/components/layout/Header/page.tsx
@@ -32,8 +32,14 @@ export default function Header() {
   // }, []);
 
   const handleLogout = () => {
-    localStorage.removeItem('accessToken');
+    // localStorage 비우기
     localStorage.removeItem('tokenType');
+    localStorage.removeItem('nickname');
+
+    // 쿠키 삭제 (accessToken)
+    document.cookie =
+      'accessToken=; path=/; expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+
     alert('다음에 또 만나요 👋');
     router.replace('/front/account/login');
   };


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolves: https://github.com/DdNnTt/Chingu-Frontend/issues/67

## 📝작업 내용
- 기존 localStorage 기반 로그인 상태 관리 로직 제거
- 로그인 성공 시 accessToken을 document.cookie에 저장
- 로그인 상태 확인 시 쿠키에서 accessToken 파싱하여 처리
- 로그아웃 시 document.cookie를 만료시켜 accessToken 제거

## 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

