### PR TITLE
친구 관련 API 연동 작업(조회/신청/삭제 API)

### DIFF
--- a/src/app/api/friends/[friendId]/route.ts
+++ b/src/app/api/friends/[friendId]/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: { friendId: string } }
+) {
+  const API_BASE = process.env.API_BASE_URL;
+  const token = req.headers.get('authorization');
+  const { friendId } = params;
+
+  console.log('[친구 삭제 API] friendUserId:', friendId);
+
+  if (!API_BASE) {
+    return NextResponse.json({ error: 'API_BASE_URL 누락됨' }, { status: 500 });
+  }
+
+  if (!token) {
+    return NextResponse.json(
+      { error: '인증 토큰이 필요합니다' },
+      { status: 401 }
+    );
+  }
+
+  try {
+    const res = await fetch(`${API_BASE}/api/friends/${friendId}`, {
+      method: 'DELETE',
+      headers: {
+        Authorization: token,
+      },
+    });
+
+    console.log('[친구 삭제 API] 백엔드 응답 상태:', res.status);
+
+    if (!res.ok) {
+      const errorText = await res.text();
+      console.error('[친구 삭제 응답 실패]', res.status, errorText);
+      return NextResponse.json(
+        { error: '친구 삭제 실패', details: errorText, status: res.status },
+        { status: res.status }
+      );
+    }
+
+    const data = await res.json();
+    console.log('[친구 삭제 API] 성공 응답:', data);
+    return NextResponse.json(data);
+  } catch (err) {
+    console.error('[친구 삭제 프록시 오류]', err);
+    return NextResponse.json({ error: '서버 오류' }, { status: 500 });
+  }
+}

--- a/src/app/api/friends/request/route.ts
+++ b/src/app/api/friends/request/route.ts
@@ -1,0 +1,106 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function POST(req: NextRequest) {
+  const API_BASE = process.env.API_BASE_URL;
+  const token = req.headers.get('authorization');
+
+  console.log('[친구 신청 API] API_BASE:', API_BASE);
+  console.log('[친구 신청 API] 토큰 존재:', !!token);
+
+  if (!API_BASE) {
+    return NextResponse.json({ error: 'API_BASE_URL 누락됨' }, { status: 500 });
+  }
+
+  if (!token) {
+    return NextResponse.json(
+      { error: '인증 토큰이 필요합니다' },
+      { status: 401 }
+    );
+  }
+
+  try {
+    const body = await req.json();
+    const { friendId } = body;
+
+    console.log('[친구 신청 API] 요청 body:', body);
+    console.log(
+      '[친구 신청 API] friendId:',
+      friendId,
+      '타입:',
+      typeof friendId
+    );
+
+    if (!friendId || typeof friendId !== 'number') {
+      return NextResponse.json(
+        { error: '유효한 friendId가 필요합니다' },
+        { status: 400 }
+      );
+    }
+
+    const requestUrl = `${API_BASE}/api/friends/request`;
+    console.log('[친구 신청 API] 백엔드 요청 URL:', requestUrl);
+
+    const res = await fetch(requestUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: token,
+      },
+      body: JSON.stringify({ friendId }),
+    });
+
+    console.log('[친구 신청 API] 백엔드 응답 상태:', res.status);
+
+    if (!res.ok) {
+      const errorText = await res.text();
+      console.error('[친구 신청 응답 실패]', res.status, errorText);
+      console.log('[친구 신청 API] 에러 텍스트 타입:', typeof errorText);
+      console.log('[친구 신청 API] 에러 텍스트 길이:', errorText.length);
+
+      // 이미 친구인 경우는 성공으로 처리
+      if (res.status === 400) {
+        console.log('[친구 신청 API] 400 에러 감지, JSON 파싱 시도');
+        try {
+          const errorData = JSON.parse(errorText);
+          console.log('[친구 신청 API] 파싱된 에러 데이터:', errorData);
+          console.log('[친구 신청 API] message 필드:', errorData.message);
+
+          if (errorData.message === '이미 친구입니다.') {
+            console.log('[친구 신청 API] 이미 친구 관계임 - 200으로 변경');
+            return NextResponse.json(
+              {
+                message: '이미 친구입니다.',
+                timestamp: errorData.timestamp || new Date().toISOString(),
+              },
+              { status: 200 }
+            );
+          } else {
+            console.log('[친구 신청 API] 다른 메시지:', errorData.message);
+          }
+        } catch (parseError) {
+          console.error('[JSON 파싱 오류]', parseError);
+          console.log('[친구 신청 API] 파싱 실패한 원본 텍스트:', errorText);
+        }
+      }
+
+      console.log('[친구 신청 API] 원본 상태 코드로 반환:', res.status);
+      return NextResponse.json(
+        { error: '친구 신청 실패', details: errorText, status: res.status },
+        { status: res.status }
+      );
+    }
+
+    const data = await res.json();
+    console.log('[친구 신청 API] 성공 응답:', data);
+    return NextResponse.json(data);
+  } catch (err) {
+    console.error('[친구 신청 프록시 오류]', err);
+    return NextResponse.json(
+      {
+        error: '서버 오류',
+        details: err instanceof Error ? err.message : '알 수 없는 오류',
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/friends/requests/route.ts
+++ b/src/app/api/friends/requests/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(request: NextRequest) {
+  try {
+    // 토큰 가져오기
+    const token = request.cookies.get('accessToken')?.value;
+    if (!token) {
+      return NextResponse.json(
+        { message: '인증 토큰이 필요합니다.' },
+        { status: 401 }
+      );
+    }
+
+    // 백엔드 API 호출
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL}/api/friends/requests`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    );
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      return NextResponse.json(data, { status: response.status });
+    }
+
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('받은 친구 요청 조회 오류:', error);
+    return NextResponse.json(
+      { message: '서버 오류가 발생했습니다.' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/friends/respond/route.ts
+++ b/src/app/api/friends/respond/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function PUT(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { friendId, status } = body;
+
+    // 토큰 가져오기
+    const token = request.cookies.get('accessToken')?.value;
+    if (!token) {
+      return NextResponse.json(
+        { message: '인증 토큰이 필요합니다.' },
+        { status: 401 }
+      );
+    }
+
+    // 백엔드 API 호출
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL}/api/friends/respond`,
+      {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ friendId, status }),
+      }
+    );
+
+    const data = await response.json();
+
+    if (!response.ok) {
+      return NextResponse.json(data, { status: response.status });
+    }
+
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('친구 요청 응답 처리 오류:', error);
+    return NextResponse.json(
+      { message: '서버 오류가 발생했습니다.' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/users/[userId]/route.ts
+++ b/src/app/api/users/[userId]/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { userId: string } }
+) {
+  const API_BASE = process.env.API_BASE_URL;
+  const token = req.headers.get('authorization');
+  const { userId } = params;
+
+  if (!API_BASE) {
+    return NextResponse.json({ error: 'API_BASE_URL 누락됨' }, { status: 500 });
+  }
+
+  try {
+    const res = await fetch(`${API_BASE}/api/users/${userId}`, {
+      method: 'GET',
+      headers: {
+        Authorization: token || '',
+      },
+    });
+
+    if (!res.ok) {
+      const errorText = await res.text();
+      console.error('[사용자 정보 조회 실패]', res.status, errorText);
+      return NextResponse.json(
+        { error: '사용자 정보 조회 실패', status: res.status },
+        { status: res.status }
+      );
+    }
+
+    const text = await res.text();
+    if (!text) {
+      console.warn('[사용자 정보 응답 본문 없음]');
+      return NextResponse.json(
+        { error: '사용자 정보가 없습니다.' },
+        { status: 404 }
+      );
+    }
+
+    const data = JSON.parse(text);
+    return NextResponse.json(data);
+  } catch (err) {
+    console.error('[사용자 정보 프록시 오류]', err);
+    return NextResponse.json({ error: '서버 오류' }, { status: 500 });
+  }
+}

--- a/src/app/front/my-home/friend-list/page.tsx
+++ b/src/app/front/my-home/friend-list/page.tsx
@@ -1,107 +1,78 @@
 'use client';
 
-import { useState, useEffect } from 'react';
-import { useRouter } from 'next/navigation';
-import axios from '@/libs/axios';
+import { useEffect, useState } from 'react';
+import axiosInstance from '@/libs/axios';
+import Link from 'next/link';
 
-type Friend = {
+interface Friend {
   friendUserId: number;
   nickname: string;
   name: string;
   score: number;
   friendSince: string;
-};
+}
 
-export default function FriendList() {
+export default function FriendListPage() {
   const [friends, setFriends] = useState<Friend[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState('');
-  const router = useRouter();
-
-  // 친구 목록 조회
-  const fetchFriends = async () => {
-    try {
-      setIsLoading(true);
-      setError('');
-      const response = await axios.get('/api/friends');
-      setFriends(response.data);
-    } catch (err) {
-      setError('친구 목록을 불러오는데 실패했습니다.');
-      console.error('친구 목록 조회 실패:', err);
-    } finally {
-      setIsLoading(false);
-    }
-  };
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    const fetchFriends = async () => {
+      try {
+        setLoading(true);
+        const response = await axiosInstance.get('/api/friends');
+        setFriends(response.data);
+      } catch (err) {
+        console.error(err);
+        setError('친구 목록을 불러오지 못했습니다.');
+      } finally {
+        setLoading(false);
+      }
+    };
     fetchFriends();
   }, []);
 
-  return (
-    <div className="friend-list-page py-4 px-4 pt-20 mx-auto rounded-lg bg-gray-100">
-      <div className="flex items-center mb-6">
-        <button
-          onClick={() => router.back()}
-          className="text-gray-600 hover:text-gray-800"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            strokeWidth={2}
-            stroke="currentColor"
-            className="w-6 h-6"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18"
-            />
-          </svg>
-        </button>
-        <h2 className="text-2xl font-semibold text-center flex-1">
-          내 친구 목록
-        </h2>
+  if (loading)
+    return (
+      <div className="p-6 text-center text-gray-500">
+        친구 목록을 불러오는 중...
       </div>
+    );
+  if (error) return <div className="p-6 text-center text-red-600">{error}</div>;
 
-      <div className="friend-list bg-white rounded-lg shadow-sm p-4 max-h-[calc(100vh-300px)] overflow-y-auto space-y-3">
-        {isLoading ? (
-          <div className="text-center py-8">
-            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-500 mx-auto"></div>
-            <p className="mt-2 text-gray-600">친구 목록을 불러오는 중...</p>
-          </div>
-        ) : error ? (
-          <div className="text-center py-8">
-            <p className="text-red-500">{error}</p>
-            <button
-              onClick={fetchFriends}
-              className="mt-2 px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600"
-            >
-              다시 시도
-            </button>
-          </div>
-        ) : friends.length === 0 ? (
-          <div className="text-center py-8">
-            <p className="text-gray-500">아직 친구가 없습니다.</p>
-          </div>
-        ) : (
-          friends.map((friend) => (
-            <div
+  return (
+    <div className="max-w-lg mx-auto p-6">
+      <h2 className="text-2xl font-bold mb-6 text-center">내 친구 목록</h2>
+      {friends.length === 0 ? (
+        <div className="text-gray-400 text-center">아직 친구가 없습니다.</div>
+      ) : (
+        <ul className="space-y-3">
+          {friends.map((friend) => (
+            <li
               key={friend.friendUserId}
-              className="friend-item flex items-center justify-between bg-gray-50 p-3 rounded-md"
+              className="flex items-center justify-between bg-white border rounded-lg shadow-sm px-4 py-3 hover:bg-blue-50 transition"
             >
-              <div className="flex items-center gap-3">
-                <span className="font-medium text-gray-800">
-                  {friend.nickname}
+              <div>
+                <span className="font-semibold text-lg">{friend.nickname}</span>
+                <span className="ml-2 text-gray-500 text-sm">
+                  ({friend.name})
+                </span>
+                <span className="ml-3 text-xs text-gray-400">
+                  친구맺은 날짜:{' '}
+                  {new Date(friend.friendSince).toLocaleDateString()}
                 </span>
               </div>
-              <div className="text-sm text-gray-500">
-                우정도 {friend.score}%
-              </div>
-            </div>
-          ))
-        )}
-      </div>
+              <Link
+                href={`/front/my-home/friend/${friend.friendUserId}`}
+                className="text-blue-600 hover:underline text-sm font-medium"
+              >
+                프로필
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 }

--- a/src/app/front/my-home/friend-requests/page.tsx
+++ b/src/app/front/my-home/friend-requests/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import axiosInstance from '@/libs/axios';
 import Link from 'next/link';
 import Button from '@/components/common/Button';
+import { AxiosError } from 'axios';
 
 interface FriendRequest {
   fromUserId: number;
@@ -34,7 +35,7 @@ export default function FriendRequestsPage() {
 
   const handleRespond = async (
     friendId: number,
-    status: 'accept' | 'reject'
+    status: 'accepted' | 'rejected'
   ) => {
     try {
       const response = await axiosInstance.put('/api/friends/respond', {
@@ -50,13 +51,26 @@ export default function FriendRequestsPage() {
       );
 
       alert(
-        status === 'accept'
+        status === 'accepted'
           ? '친구 요청을 수락했습니다!'
           : '친구 요청을 거절했습니다.'
       );
     } catch (err) {
       console.error('친구 요청 응답 실패:', err);
-      alert('요청 처리에 실패했습니다.');
+
+      if (err instanceof AxiosError) {
+        console.error('에러 응답 데이터:', err.response?.data);
+        console.error('에러 상태 코드:', err.response?.status);
+
+        // 에러 메시지 표시
+        const errorMessage =
+          err.response?.data?.message ||
+          err.response?.data?.error ||
+          '요청 처리에 실패했습니다.';
+        alert(`에러: ${errorMessage}`);
+      } else {
+        alert('요청 처리에 실패했습니다.');
+      }
     }
   };
 
@@ -106,14 +120,14 @@ export default function FriendRequestsPage() {
               <div className="flex gap-2">
                 <Button
                   type="button"
-                  onClick={() => handleRespond(request.fromUserId, 'accept')}
+                  onClick={() => handleRespond(request.fromUserId, 'accepted')}
                   className="bg-green-600 text-white text-sm px-3 py-1"
                 >
                   수락
                 </Button>
                 <Button
                   type="button"
-                  onClick={() => handleRespond(request.fromUserId, 'reject')}
+                  onClick={() => handleRespond(request.fromUserId, 'rejected')}
                   className="bg-red-600 text-white text-sm px-3 py-1"
                 >
                   거절

--- a/src/app/front/my-home/friend-requests/page.tsx
+++ b/src/app/front/my-home/friend-requests/page.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import axiosInstance from '@/libs/axios';
+import Link from 'next/link';
+import Button from '@/components/common/Button';
+
+interface FriendRequest {
+  fromUserId: number;
+  nickname: string;
+  requestedAt: string;
+}
+
+export default function FriendRequestsPage() {
+  const [friendRequests, setFriendRequests] = useState<FriendRequest[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchFriendRequests = async () => {
+      try {
+        setLoading(true);
+        const response = await axiosInstance.get('/api/friends/requests');
+        setFriendRequests(response.data);
+      } catch (err) {
+        console.error(err);
+        setError('받은 친구 요청을 불러오지 못했습니다.');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchFriendRequests();
+  }, []);
+
+  const handleRespond = async (
+    friendId: number,
+    status: 'accept' | 'reject'
+  ) => {
+    try {
+      const response = await axiosInstance.put('/api/friends/respond', {
+        friendId,
+        status,
+      });
+
+      console.log('친구 요청 응답 성공:', response.data);
+
+      // 성공 시 목록에서 제거
+      setFriendRequests((prev) =>
+        prev.filter((req) => req.fromUserId !== friendId)
+      );
+
+      alert(
+        status === 'accept'
+          ? '친구 요청을 수락했습니다!'
+          : '친구 요청을 거절했습니다.'
+      );
+    } catch (err) {
+      console.error('친구 요청 응답 실패:', err);
+      alert('요청 처리에 실패했습니다.');
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="p-6 text-center text-gray-500">
+        받은 친구 요청을 불러오는 중...
+      </div>
+    );
+  }
+
+  if (error) {
+    return <div className="p-6 text-center text-red-600">{error}</div>;
+  }
+
+  return (
+    <div className="max-w-lg mx-auto p-6">
+      <div className="flex items-center justify-between mb-6">
+        <h2 className="text-2xl font-bold">받은 친구 요청</h2>
+        <Link
+          href="/front/my-home"
+          className="text-blue-600 hover:underline text-sm"
+        >
+          ← 뒤로
+        </Link>
+      </div>
+
+      {friendRequests.length === 0 ? (
+        <div className="text-gray-400 text-center">
+          받은 친구 요청이 없습니다.
+        </div>
+      ) : (
+        <ul className="space-y-3">
+          {friendRequests.map((request) => (
+            <li
+              key={request.fromUserId}
+              className="flex items-center justify-between bg-white border rounded-lg shadow-sm px-4 py-3"
+            >
+              <div>
+                <span className="font-semibold text-lg">
+                  {request.nickname}
+                </span>
+                <div className="text-xs text-gray-400 mt-1">
+                  요청일: {new Date(request.requestedAt).toLocaleDateString()}
+                </div>
+              </div>
+              <div className="flex gap-2">
+                <Button
+                  type="button"
+                  onClick={() => handleRespond(request.fromUserId, 'accept')}
+                  className="bg-green-600 text-white text-sm px-3 py-1"
+                >
+                  수락
+                </Button>
+                <Button
+                  type="button"
+                  onClick={() => handleRespond(request.fromUserId, 'reject')}
+                  className="bg-red-600 text-white text-sm px-3 py-1"
+                >
+                  거절
+                </Button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/app/front/my-home/friend/[friendId]/page.tsx
+++ b/src/app/front/my-home/friend/[friendId]/page.tsx
@@ -4,6 +4,8 @@ import { useEffect, useState } from 'react';
 import Image from 'next/image';
 import Button from '@/components/common/Button';
 import { useRouter, useParams } from 'next/navigation';
+import axios, { isAxiosError } from 'axios';
+import axiosInstance from '@/libs/axios';
 
 interface User {
   id: number;
@@ -18,6 +20,14 @@ interface User {
   socialType: string;
 }
 
+interface Friend {
+  friendUserId: number;
+  nickname: string;
+  name: string;
+  score: number;
+  friendSince: string;
+}
+
 export default function FriendDetailPage() {
   const router = useRouter();
   const params = useParams();
@@ -26,26 +36,37 @@ export default function FriendDetailPage() {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [friendRequestLoading, setFriendRequestLoading] = useState(false);
+  const [friendStatus, setFriendStatus] = useState<
+    'none' | 'requested' | 'friend'
+  >('none');
 
   useEffect(() => {
     const fetchUserInfo = async () => {
       try {
         setLoading(true);
-        const response = await fetch(`/api/users/${friendId}`);
+        const response = await axiosInstance.get(`/api/users/${friendId}`);
 
-        if (!response.ok) {
-          if (response.status === 404) {
-            setError('해당 사용자를 찾을 수 없습니다.');
-          } else {
-            throw new Error('사용자 정보를 불러오는데 실패했습니다.');
-          }
+        if (response.status === 404) {
+          setError('해당 사용자를 찾을 수 없습니다.');
           return;
         }
 
-        const userData: User = await response.json();
+        const userData: User = response.data;
         setUser(userData);
+
+        // 친구 관계 확인
+        await checkFriendStatus(userData.id);
       } catch (err) {
-        setError(err instanceof Error ? err.message : '오류가 발생했습니다.');
+        if (axios.isAxiosError(err)) {
+          if (err.response?.status === 404) {
+            setError('해당 사용자를 찾을 수 없습니다.');
+          } else {
+            setError('사용자 정보를 불러오는데 실패했습니다.');
+          }
+        } else {
+          setError('오류가 발생했습니다.');
+        }
       } finally {
         setLoading(false);
       }
@@ -56,12 +77,166 @@ export default function FriendDetailPage() {
     }
   }, [friendId]);
 
+  // 친구 관계 확인 함수
+  const checkFriendStatus = async (targetUserId: number) => {
+    try {
+      console.log('[친구 관계 확인] targetUserId:', targetUserId);
+
+      // 친구 목록을 조회하여 이미 친구인지 확인
+      const response = await axiosInstance.get('/api/friends');
+      const friendsList = response.data;
+
+      console.log('[친구 관계 확인] 친구 목록:', friendsList);
+
+      // 친구 목록에서 해당 사용자가 있는지 확인
+      const isFriend = friendsList.some(
+        (friend: Friend) => friend.friendUserId === targetUserId
+      );
+
+      if (isFriend) {
+        console.log('[친구 관계 확인] 이미 친구 관계임');
+        setFriendStatus('friend');
+        return;
+      }
+
+      // 친구가 아니라면 친구 신청 API를 호출하여 이미 요청을 보냈는지 확인
+      try {
+        await axiosInstance.post('/api/friends/request', {
+          friendId: targetUserId,
+        });
+
+        // 성공적으로 친구 신청이 되었다면 아직 요청을 보내지 않음
+        console.log('[친구 관계 확인] 아직 친구 요청을 보내지 않음');
+        setFriendStatus('none');
+      } catch (requestErr) {
+        if (isAxiosError(requestErr)) {
+          if (requestErr.response?.status === 400) {
+            if (
+              requestErr.response.data?.message ===
+              '이미 친구 요청을 보냈습니다.'
+            ) {
+              console.log('[친구 관계 확인] 이미 친구 요청을 보냄');
+              setFriendStatus('requested');
+              return;
+            } else if (
+              requestErr.response.data?.message === '이미 친구입니다.'
+            ) {
+              console.log('[친구 관계 확인] 이미 친구 관계임');
+              setFriendStatus('friend');
+              return;
+            }
+          }
+        }
+
+        // 기타 에러는 none으로 처리
+        console.log('[친구 관계 확인] 기타 에러:', requestErr);
+        setFriendStatus('none');
+      }
+    } catch (err) {
+      console.error('[친구 관계 확인 에러]', err);
+      if (isAxiosError(err)) {
+        console.log('[친구 관계 확인] API 에러:', err.response?.data);
+      }
+      // 에러 발생 시 기본값으로 설정
+      setFriendStatus('none');
+    }
+  };
+
   const handleSendMessage = () => {
     router.push('/front/message/write');
   };
 
   const handleGoBack = () => {
     router.back();
+  };
+
+  const handleFriendRequest = async () => {
+    if (!user) return;
+
+    console.log('[친구 신청] 사용자 정보:', user);
+    console.log('[친구 신청] friendId:', user.id, '타입:', typeof user.id);
+
+    // 이미 친구인 경우 친구 끊기 처리
+    if (friendStatus === 'friend') {
+      const confirmUnfriend = confirm('정말로 이 친구와 끊으시겠습니까?');
+      if (!confirmUnfriend) return;
+
+      try {
+        setFriendRequestLoading(true);
+
+        const response = await axiosInstance.delete(`/api/friends/${user.id}`);
+        console.log('[친구 끊기 성공]', response.data);
+
+        setFriendStatus('none');
+        alert('친구 관계가 해제되었습니다.');
+      } catch (err) {
+        console.error('[친구 끊기 에러]', err);
+        if (isAxiosError(err)) {
+          alert(err.response?.data?.error || '친구 끊기에 실패했습니다.');
+        } else {
+          alert('친구 끊기에 실패했습니다.');
+        }
+      } finally {
+        setFriendRequestLoading(false);
+      }
+      return;
+    }
+
+    // 친구 신청 처리
+    try {
+      setFriendRequestLoading(true);
+
+      const response = await axiosInstance.post('/api/friends/request', {
+        friendId: user.id,
+      });
+
+      console.log('[친구 신청 성공]', response.data);
+      setFriendStatus('requested');
+      alert('친구 신청이 전송되었습니다!');
+    } catch (err) {
+      console.error('[친구 신청 에러 전체]', err);
+
+      if (isAxiosError(err)) {
+        console.error('[친구 신청 Axios 에러]', {
+          status: err.response?.status,
+          statusText: err.response?.statusText,
+          data: err.response?.data,
+          headers: err.response?.headers,
+        });
+
+        // 이미 친구인 경우는 성공으로 처리
+        if (
+          err.response?.status === 400 &&
+          err.response.data?.message === '이미 친구입니다.'
+        ) {
+          console.log('[친구 신청] 이미 친구 관계임');
+          setFriendStatus('friend');
+          return;
+        }
+
+        // 이미 친구 요청을 보낸 경우는 requested 상태로 처리
+        if (
+          err.response?.status === 400 &&
+          err.response.data?.message === '이미 친구 요청을 보냈습니다.'
+        ) {
+          console.log('[친구 신청] 이미 친구 요청을 보냄');
+          setFriendStatus('requested');
+          return;
+        }
+
+        const errorMessage =
+          err.response?.data?.error ||
+          err.response?.data?.details ||
+          '친구 신청에 실패했습니다.';
+        console.error('[친구 신청] 에러 메시지:', errorMessage);
+        alert(errorMessage);
+      } else {
+        console.error('[친구 신청] 알 수 없는 에러:', err);
+        alert('친구 신청에 실패했습니다.');
+      }
+    } finally {
+      setFriendRequestLoading(false);
+    }
   };
 
   if (loading) {
@@ -156,9 +331,28 @@ export default function FriendDetailPage() {
       </div>
 
       <div className="flex gap-2 mb-4">
-        <Button type="button" className="flex-1 text-white bg-red-600">
-          친구 끊기
-        </Button>
+        <div className="flex-1 relative">
+          <Button
+            type="button"
+            className={`w-full text-white ${
+              friendStatus === 'friend'
+                ? 'bg-red-600 hover:bg-red-700'
+                : friendStatus === 'requested'
+                  ? 'bg-gray-400 cursor-not-allowed'
+                  : 'bg-blue-600'
+            }`}
+            onClick={handleFriendRequest}
+            disabled={friendRequestLoading || friendStatus === 'requested'}
+          >
+            {friendRequestLoading
+              ? '신청 중...'
+              : friendStatus === 'friend'
+                ? '친구 끊기'
+                : friendStatus === 'requested'
+                  ? '신청 완료'
+                  : '친구 맺기'}
+          </Button>
+        </div>
         <Button
           type="button"
           className="flex-1 text-white bg-blue-600"

--- a/src/app/front/my-home/friend/[friendId]/page.tsx
+++ b/src/app/front/my-home/friend/[friendId]/page.tsx
@@ -37,9 +37,7 @@ export default function FriendDetailPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [friendRequestLoading, setFriendRequestLoading] = useState(false);
-  const [friendStatus, setFriendStatus] = useState<
-    'none' | 'requested' | 'friend'
-  >('none');
+  const [friendSince, setFriendSince] = useState<string>('');
 
   useEffect(() => {
     const fetchUserInfo = async () => {
@@ -54,6 +52,7 @@ export default function FriendDetailPage() {
 
         const userData: User = response.data;
         setUser(userData);
+        setFriendSince(userData.friendSince);
 
         // 친구 관계 확인
         await checkFriendStatus(userData.id);
@@ -95,42 +94,38 @@ export default function FriendDetailPage() {
 
       if (isFriend) {
         console.log('[친구 관계 확인] 이미 친구 관계임');
-        setFriendStatus('friend');
-        return;
-      }
+        setFriendSince(
+          friendsList.find((f: Friend) => f.friendUserId === targetUserId)
+            ?.friendSince || ''
+        );
+      } else {
+        // 친구가 아니라면 친구 신청 API를 호출하여 이미 요청을 보냈는지 확인
+        try {
+          await axiosInstance.post('/api/friends/request', {
+            friendId: targetUserId,
+          });
 
-      // 친구가 아니라면 친구 신청 API를 호출하여 이미 요청을 보냈는지 확인
-      try {
-        await axiosInstance.post('/api/friends/request', {
-          friendId: targetUserId,
-        });
-
-        // 성공적으로 친구 신청이 되었다면 아직 요청을 보내지 않음
-        console.log('[친구 관계 확인] 아직 친구 요청을 보내지 않음');
-        setFriendStatus('none');
-      } catch (requestErr) {
-        if (isAxiosError(requestErr)) {
-          if (requestErr.response?.status === 400) {
-            if (
-              requestErr.response.data?.message ===
-              '이미 친구 요청을 보냈습니다.'
-            ) {
-              console.log('[친구 관계 확인] 이미 친구 요청을 보냄');
-              setFriendStatus('requested');
-              return;
-            } else if (
-              requestErr.response.data?.message === '이미 친구입니다.'
-            ) {
-              console.log('[친구 관계 확인] 이미 친구 관계임');
-              setFriendStatus('friend');
-              return;
+          // 성공적으로 친구 신청이 되었다면 아직 요청을 보내지 않음
+          console.log('[친구 관계 확인] 아직 친구 요청을 보내지 않음');
+        } catch (requestErr) {
+          if (isAxiosError(requestErr)) {
+            if (requestErr.response?.status === 400) {
+              if (
+                requestErr.response.data?.message ===
+                '이미 친구 요청을 보냈습니다.'
+              ) {
+                console.log('[친구 관계 확인] 이미 친구 요청을 보냄');
+              } else if (
+                requestErr.response.data?.message === '이미 친구입니다.'
+              ) {
+                console.log('[친구 관계 확인] 이미 친구 관계임');
+              }
             }
           }
-        }
 
-        // 기타 에러는 none으로 처리
-        console.log('[친구 관계 확인] 기타 에러:', requestErr);
-        setFriendStatus('none');
+          // 기타 에러는 none으로 처리
+          console.log('[친구 관계 확인] 기타 에러:', requestErr);
+        }
       }
     } catch (err) {
       console.error('[친구 관계 확인 에러]', err);
@@ -138,7 +133,7 @@ export default function FriendDetailPage() {
         console.log('[친구 관계 확인] API 에러:', err.response?.data);
       }
       // 에러 발생 시 기본값으로 설정
-      setFriendStatus('none');
+      setFriendSince('');
     }
   };
 
@@ -157,7 +152,7 @@ export default function FriendDetailPage() {
     console.log('[친구 신청] friendId:', user.id, '타입:', typeof user.id);
 
     // 이미 친구인 경우 친구 끊기 처리
-    if (friendStatus === 'friend') {
+    if (friendSince) {
       const confirmUnfriend = confirm('정말로 이 친구와 끊으시겠습니까?');
       if (!confirmUnfriend) return;
 
@@ -167,7 +162,7 @@ export default function FriendDetailPage() {
         const response = await axiosInstance.delete(`/api/friends/${user.id}`);
         console.log('[친구 끊기 성공]', response.data);
 
-        setFriendStatus('none');
+        setFriendSince('');
         alert('친구 관계가 해제되었습니다.');
       } catch (err) {
         console.error('[친구 끊기 에러]', err);
@@ -191,7 +186,7 @@ export default function FriendDetailPage() {
       });
 
       console.log('[친구 신청 성공]', response.data);
-      setFriendStatus('requested');
+      setFriendSince(response.data.friendSince);
       alert('친구 신청이 전송되었습니다!');
     } catch (err) {
       console.error('[친구 신청 에러 전체]', err);
@@ -210,7 +205,7 @@ export default function FriendDetailPage() {
           err.response.data?.message === '이미 친구입니다.'
         ) {
           console.log('[친구 신청] 이미 친구 관계임');
-          setFriendStatus('friend');
+          setFriendSince(response.data.friendSince);
           return;
         }
 
@@ -220,7 +215,7 @@ export default function FriendDetailPage() {
           err.response.data?.message === '이미 친구 요청을 보냈습니다.'
         ) {
           console.log('[친구 신청] 이미 친구 요청을 보냄');
-          setFriendStatus('requested');
+          setFriendSince(response.data.friendSince);
           return;
         }
 
@@ -296,7 +291,7 @@ export default function FriendDetailPage() {
           ← 뒤로
         </Button>
         <h2 className="text-2xl font-semibold text-center w-full">
-          사용자 마이 홈
+          친구 마이 홈
         </h2>
       </div>
 
@@ -310,7 +305,14 @@ export default function FriendDetailPage() {
             className="object-cover rounded-full border border-gray-300"
           />
           <div className="profile-info">
-            <h3 className="text-lg font-semibold">{user.nickname}</h3>
+            <div className="flex items-center gap-2">
+              <h3 className="text-lg font-semibold">{user.nickname}</h3>
+              {friendSince && (
+                <span className="bg-green-100 text-green-800 text-xs px-2 py-1 rounded-full">
+                  친구
+                </span>
+              )}
+            </div>
             <p className="text-sm text-gray-500">이름: {user.name}</p>
             <p className="text-sm text-gray-500">ID: {user.userId}</p>
           </div>
@@ -335,22 +337,16 @@ export default function FriendDetailPage() {
           <Button
             type="button"
             className={`w-full text-white ${
-              friendStatus === 'friend'
-                ? 'bg-red-600 hover:bg-red-700'
-                : friendStatus === 'requested'
-                  ? 'bg-gray-400 cursor-not-allowed'
-                  : 'bg-blue-600'
+              friendSince ? 'bg-red-600 hover:bg-red-700' : 'bg-blue-600'
             }`}
             onClick={handleFriendRequest}
-            disabled={friendRequestLoading || friendStatus === 'requested'}
+            disabled={friendRequestLoading || !!friendSince}
           >
             {friendRequestLoading
               ? '신청 중...'
-              : friendStatus === 'friend'
+              : friendSince
                 ? '친구 끊기'
-                : friendStatus === 'requested'
-                  ? '신청 완료'
-                  : '친구 맺기'}
+                : '친구 맺기'}
           </Button>
         </div>
         <Button

--- a/src/app/front/my-home/friend/[friendId]/page.tsx
+++ b/src/app/front/my-home/friend/[friendId]/page.tsx
@@ -1,0 +1,190 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Image from 'next/image';
+import Button from '@/components/common/Button';
+import { useRouter, useParams } from 'next/navigation';
+
+interface User {
+  id: number;
+  userId: string;
+  name: string;
+  nickname: string;
+  email: string;
+  profilePictureUrl: string;
+  bio: string;
+  joinDate: string;
+  lastLoginDate: string;
+  socialType: string;
+}
+
+export default function FriendDetailPage() {
+  const router = useRouter();
+  const params = useParams();
+  const friendId = params.friendId as string;
+
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchUserInfo = async () => {
+      try {
+        setLoading(true);
+        const response = await fetch(`/api/users/${friendId}`);
+
+        if (!response.ok) {
+          if (response.status === 404) {
+            setError('해당 사용자를 찾을 수 없습니다.');
+          } else {
+            throw new Error('사용자 정보를 불러오는데 실패했습니다.');
+          }
+          return;
+        }
+
+        const userData: User = await response.json();
+        setUser(userData);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : '오류가 발생했습니다.');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (friendId) {
+      fetchUserInfo();
+    }
+  }, [friendId]);
+
+  const handleSendMessage = () => {
+    router.push('/front/message/write');
+  };
+
+  const handleGoBack = () => {
+    router.back();
+  };
+
+  if (loading) {
+    return (
+      <div className="my-home-page py-4 px-4 pt-20 mx-auto rounded-lg bg-gray-100">
+        <div className="text-center py-8">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mx-auto"></div>
+          <p className="mt-2 text-gray-600">사용자 정보를 불러오는 중...</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="my-home-page py-4 px-4 pt-20 mx-auto rounded-lg bg-gray-100">
+        <div className="text-center py-8">
+          <p className="text-red-600 mb-4">{error}</p>
+          <Button
+            type="button"
+            onClick={handleGoBack}
+            className="bg-blue-600 text-white"
+          >
+            뒤로 가기
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div className="my-home-page py-4 px-4 pt-20 mx-auto rounded-lg bg-gray-100">
+        <div className="text-center py-8">
+          <p className="text-gray-600 mb-4">사용자 정보를 찾을 수 없습니다.</p>
+          <Button
+            type="button"
+            onClick={handleGoBack}
+            className="bg-blue-600 text-white"
+          >
+            뒤로 가기
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="my-home-page py-4 px-4 pt-20 mx-auto rounded-lg bg-gray-100">
+      <div className="relative mb-6 min-h-[40px] flex items-center justify-center">
+        <Button
+          type="button"
+          onClick={handleGoBack}
+          variant="secondary"
+          className="absolute left-0 top-1/2 -translate-y-1/2 px-3 py-1 text-sm"
+        >
+          ← 뒤로
+        </Button>
+        <h2 className="text-2xl font-semibold text-center w-full">
+          사용자 마이 홈
+        </h2>
+      </div>
+
+      <div className="profile-card flex items-center justify-between mb-4 p-4 bg-white rounded-lg shadow-sm gap-2">
+        <div className="flex items-center gap-2">
+          <Image
+            src={user.profilePictureUrl || '/images/test-profile.png'}
+            alt="프로필 사진"
+            width={64}
+            height={64}
+            className="object-cover rounded-full border border-gray-300"
+          />
+          <div className="profile-info">
+            <h3 className="text-lg font-semibold">{user.nickname}</h3>
+            <p className="text-sm text-gray-500">이름: {user.name}</p>
+            <p className="text-sm text-gray-500">ID: {user.userId}</p>
+          </div>
+        </div>
+        <div className="text-right">
+          <p className="text-xs text-gray-500">
+            가입일: {new Date(user.joinDate).toLocaleDateString()}
+          </p>
+          <p className="text-xs text-gray-500">
+            마지막 로그인: {new Date(user.lastLoginDate).toLocaleDateString()}
+          </p>
+        </div>
+      </div>
+
+      <div className="profile-intro p-4 bg-white rounded-lg shadow-sm mb-4">
+        <h4 className="font-semibold mb-2">자기소개</h4>
+        <p className="text-gray-700">{user.bio || '자기소개가 없습니다.'}</p>
+      </div>
+
+      <div className="flex gap-2 mb-4">
+        <Button type="button" className="flex-1 text-white bg-red-600">
+          친구 끊기
+        </Button>
+        <Button
+          type="button"
+          className="flex-1 text-white bg-blue-600"
+          onClick={handleSendMessage}
+        >
+          쪽지 보내기
+        </Button>
+      </div>
+
+      <div className="schedule-calendar bg-white p-6 rounded-lg shadow-sm mb-4 text-center text-gray-500">
+        일정 캘린더가 들어갈 부분
+      </div>
+
+      <div className="my-groups bg-white p-4 rounded-lg shadow-sm">
+        <h3 className="text-lg font-semibold mb-2">내 그룹 목록</h3>
+        <div className="group-item bg-gray-200 p-3 rounded mb-2">그룹1</div>
+        <div className="group-item bg-gray-200 p-3 rounded mb-2">그룹2</div>
+        <div className="group-item bg-gray-200 p-3 rounded">그룹3</div>
+
+        <Button
+          type="button"
+          className="flex-1 w-full bg-blue-600 text-white mt-4"
+        >
+          더보기
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/app/front/my-home/page.tsx
+++ b/src/app/front/my-home/page.tsx
@@ -72,10 +72,14 @@ export default function MyHome() {
   // 친구 목록 조회
   const fetchFriends = async () => {
     try {
+      setIsLoading(true);
       const response = await axios.get('/api/friends');
       setFriends(response.data);
     } catch (err) {
-      console.error('친구 목록 조회 실패:', err);
+      console.error(err);
+      setError('친구 목록을 불러오지 못했습니다.');
+    } finally {
+      setIsLoading(false);
     }
   };
 

--- a/src/app/front/my-home/page.tsx
+++ b/src/app/front/my-home/page.tsx
@@ -6,7 +6,7 @@ import Button from '@/components/common/Button';
 import ScheduleModal from '@/components/my-home/ScheduleModal';
 import ScheduleEditModal from '@/components/my-home/ScheduleEditModal';
 import { useState, useEffect } from 'react';
-import axios from '@/libs/axios';
+import axiosInstance from '@/libs/axios';
 import { useRouter } from 'next/navigation';
 import { getCookieValue } from '@/utils/cookie';
 
@@ -45,13 +45,20 @@ interface Friend {
   friendSince: string;
 }
 
+interface FriendRequest {
+  fromUserId: number;
+  nickname: string;
+  requestedAt: string;
+}
+
 export default function MyHome() {
-  const [nickname, setNickname] = useState('');
+  const [nickname, setNickname] = useState<string>('');
   const [isScheduleModalOpen, setIsScheduleModalOpen] = useState(false);
   const [schedules, setSchedules] = useState<Schedule[]>([]);
   const [friends, setFriends] = useState<Friend[]>([]);
+  const [friendRequests, setFriendRequests] = useState<FriendRequest[]>([]);
   const [isLoading, setIsLoading] = useState(true);
-  const [error, setError] = useState('');
+  const [error, setError] = useState<string | null>(null);
   const [selectedSchedule, setSelectedSchedule] = useState<Schedule | null>(
     null
   );
@@ -62,7 +69,7 @@ export default function MyHome() {
   // 일정 목록 조회
   const fetchSchedules = async () => {
     try {
-      const response = await axios.get('/api/schedules');
+      const response = await axiosInstance.get('/api/schedules');
       setSchedules(response.data);
     } catch (err) {
       console.error('일정 조회 실패:', err);
@@ -72,14 +79,19 @@ export default function MyHome() {
   // 친구 목록 조회
   const fetchFriends = async () => {
     try {
-      setIsLoading(true);
-      const response = await axios.get('/api/friends');
+      const response = await axiosInstance.get('/api/friends');
       setFriends(response.data);
     } catch (err) {
-      console.error(err);
-      setError('친구 목록을 불러오지 못했습니다.');
-    } finally {
-      setIsLoading(false);
+      console.error('친구 목록 조회 실패:', err);
+    }
+  };
+
+  const fetchFriendRequests = async () => {
+    try {
+      const response = await axiosInstance.get('/api/friends/requests');
+      setFriendRequests(response.data);
+    } catch (err) {
+      console.error('받은 친구 요청 조회 실패:', err);
     }
   };
 
@@ -88,7 +100,11 @@ export default function MyHome() {
       setIsLoading(true);
       setError('');
       try {
-        await Promise.all([fetchSchedules(), fetchFriends()]);
+        await Promise.all([
+          fetchSchedules(),
+          fetchFriends(),
+          fetchFriendRequests(),
+        ]);
       } catch {
         setError('데이터를 불러오는데 실패했습니다.');
       } finally {
@@ -186,12 +202,20 @@ export default function MyHome() {
         <div className="profile-info">
           {/* <h3 className="text-lg font-semibold">닉네임</h3> */}
           <h3 className="text-lg font-semibold">{nickname || '닉네임'}</h3>
-          <Link
-            href="/front/my-home/friend-list"
-            className="text-sm text-gray-500 hover:text-gray-700"
-          >
-            친구 수 <span>{friends.length}</span>
-          </Link>
+          <div className="flex gap-4">
+            <Link
+              href="/front/my-home/friend-list"
+              className="text-sm text-gray-500 hover:text-gray-700"
+            >
+              친구 수 <span>{friends.length}</span>
+            </Link>
+            <Link
+              href="/front/my-home/friend-requests"
+              className="text-sm text-gray-500 hover:text-gray-700"
+            >
+              받은 친구 요청 <span>{friendRequests.length}</span>
+            </Link>
+          </div>
         </div>
       </div>
 


### PR DESCRIPTION
## #️⃣연관된 이슈

- resolves: https://github.com/DdNnTt/Chingu-Frontend/issues/80

## 📝작업 내용
- 친구 마이홈 API 추가 및 route 페이지 추가
- 친구 조회/신청/삭제 API 연동 
- 친구 요청 리스트, 요청 수락 API 연동
- 친구 관계일 경우 마이홈에 뱃지 표시

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
![image](https://github.com/user-attachments/assets/0ed957ec-6e4f-437b-b84d-7ccfc657a0ba)
![image](https://github.com/user-attachments/assets/f6685402-7199-4415-b5f6-50b58dba29bb)
http://localhost:3000/front/my-home/friend-list
여기서 프로필을 클릭하면 친구를 찾을 수 없습니다 로 나올 수 있는데,
백엔드 api 요청 응답에 하나 추가 요청할 게 있어서 이후에 수정할 예정입니다!
참고 부탁드립니다.🙇‍♀️