### PR TITLE
그룹 관련 UI 개선 및 경로 활성화 표시

### DIFF
--- a/src/app/front/components/layout/Dockbar/page.tsx
+++ b/src/app/front/components/layout/Dockbar/page.tsx
@@ -7,12 +7,17 @@ import { Home, Users, UserCircle, Mail } from 'lucide-react';
 export default function Dockbar() {
   const pathname = usePathname();
 
+  console.log('📍 current pathname:', pathname); // ← 확인용
+
   const items = [
     { href: '/front/my-home', label: '마이홈', icon: <Home size={20} /> },
     {
       href: '/front/my-home/group-list',
       label: '그룹',
       icon: <Users size={20} />,
+      isActive:
+        pathname.includes('/front/my-home/group') ||
+        pathname.includes('/front/my-home/member'),
     },
     {
       href: '/front/my-page',
@@ -29,7 +34,9 @@ export default function Dockbar() {
           <Link
             key={item.href}
             href={item.href}
-            className={`flex flex-col items-center gap-1 ${pathname === item.href ? 'text-[#aa96fc]' : ''}`}
+            className={`flex flex-col items-center gap-1 ${
+              item.isActive || pathname === item.href ? 'text-[#aa96fc]' : ''
+            }`}
           >
             {item.icon}
             <span className="text-xs">{item.label}</span>

--- a/src/app/front/my-home/group-list/page.tsx
+++ b/src/app/front/my-home/group-list/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import Button from '@/components/common/Button';
 import Link from 'next/link';
 
 type Group = {
@@ -194,12 +195,13 @@ export default function GroupList() {
 
         {visibleGroups < groups.length && (
           <div className="text-center mt-2">
-            <button
+            <Button
+              type="button"
               onClick={() => setVisibleGroups((prev) => prev + 3)}
-              className="text-sm text-blue-600 hover:underline"
+              className="flex-1 w-full bg-blue-600 text-white mt-4"
             >
               더보기
-            </button>
+            </Button>
           </div>
         )}
       </div>
@@ -235,12 +237,13 @@ export default function GroupList() {
 
         {visibleInvites < invites.length && (
           <div className="text-center mt-2">
-            <button
+            <Button
+              type="button"
               onClick={() => setVisibleInvites((prev) => prev + 3)}
-              className="text-sm text-blue-600 hover:underline"
+              className="text-sm text-blue-600"
             >
               더보기
-            </button>
+            </Button>
           </div>
         )}
       </div>

--- a/src/app/front/my-home/group/add/page.tsx
+++ b/src/app/front/my-home/group/add/page.tsx
@@ -116,7 +116,31 @@ export default function GroupAdd() {
 
   return (
     <div className="group-add-page py-4 px-4 pt-20 mx-auto rounded-lg bg-gray-100">
-      <h2 className="text-2xl font-semibold mb-6 text-center">내 그룹 목록</h2>
+      <div className="flex items-center mb-6">
+        <button
+          onClick={() => router.back()}
+          className="text-gray-600 hover:text-gray-800"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={2}
+            stroke="currentColor"
+            className="w-6 h-6"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18"
+            />
+          </svg>
+        </button>
+        <h2 className="text-2xl font-semibold text-center flex-1">
+          내 그룹 생성
+        </h2>
+      </div>
+
       <form onSubmit={handleSubmit} className="space-y-4">
         {/* 그룹명 입력 */}
         <div className="mb-4 p-4 bg-white rounded-lg shadow-sm gap-2">

--- a/src/app/front/my-home/group/detail/page.tsx
+++ b/src/app/front/my-home/group/detail/page.tsx
@@ -48,9 +48,29 @@ export default function GroupDetail() {
 
   return (
     <div className="group-detail-page py-4 px-4 pt-20 mx-auto rounded-lg bg-gray-100">
-      <h2 className="text-2xl font-semibold text-center flex-1 mb-6">
-        그룹 상세
-      </h2>
+      <div className="flex items-center mb-6">
+        <button
+          onClick={() => router.back()}
+          className="text-gray-600 hover:text-gray-800"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={2}
+            stroke="currentColor"
+            className="w-6 h-6"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18"
+            />
+          </svg>
+        </button>
+        <h2 className="text-2xl font-semibold text-center flex-1">그룹 상세</h2>
+      </div>
+
       {/* 그룹 이름 */}
       <div className="bg-white p-4 rounded-md shadow mb-4 flex items-center justify-between">
         <h1 className="text-xl font-bold">{groupName}</h1>

--- a/src/app/front/my-home/member/list/page.tsx
+++ b/src/app/front/my-home/member/list/page.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Button from '@/components/common/Button';
 
 type Member = {
   userId: number;
@@ -12,6 +14,7 @@ export default function MemberDetail() {
   const [members, setMembers] = useState<Member[]>([]);
   const [visibleMembers, setVisibleMembers] = useState(10);
   const [isLoading, setIsLoading] = useState(true);
+  const router = useRouter();
 
   useEffect(() => {
     // 임시 데이터 (추후 API 연동 예정)
@@ -27,9 +30,30 @@ export default function MemberDetail() {
 
   return (
     <div className="member-list-page py-4 px-4 pt-20 mx-auto rounded-lg bg-gray-100 min-h-screen">
-      <div className="bg-white rounded-lg shadow-md p-6">
-        <h2 className="text-xl font-bold text-center mb-4">멤버 목록</h2>
+      <div className="flex items-center mb-6">
+        <button
+          onClick={() => router.back()}
+          className="text-gray-600 hover:text-gray-800"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={2}
+            stroke="currentColor"
+            className="w-6 h-6"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18"
+            />
+          </svg>
+        </button>
+        <h2 className="text-2xl font-semibold text-center flex-1">멤버 목록</h2>
+      </div>
 
+      <div className="bg-white rounded-lg shadow-md p-6">
         <div className="space-y-2 max-h-[530px] overflow-y-auto scroll-overlay">
           {isLoading ? (
             <p className="text-center text-gray-100 text-sm">불러오는 중...</p>
@@ -48,12 +72,13 @@ export default function MemberDetail() {
 
         {visibleMembers < members.length && (
           <div className="text-center mt-4">
-            <button
+            <Button
+              type="button"
               onClick={() => setVisibleMembers((prev) => prev + 5)}
-              className="text-sm text-blue-600 hover:underline"
+              className="text-sm text-blue-600 w-full"
             >
               더보기
-            </button>
+            </Button>
           </div>
         )}
       </div>

--- a/src/app/front/my-home/page.tsx
+++ b/src/app/front/my-home/page.tsx
@@ -51,11 +51,19 @@ interface FriendRequest {
   requestedAt: string;
 }
 
+interface Group {
+  groupId: number;
+  groupName: string;
+  description: string;
+  createdAt: string;
+}
+
 export default function MyHome() {
   const [nickname, setNickname] = useState<string>('');
   const [isScheduleModalOpen, setIsScheduleModalOpen] = useState(false);
   const [schedules, setSchedules] = useState<Schedule[]>([]);
   const [friends, setFriends] = useState<Friend[]>([]);
+  const [groups, setGroups] = useState<Group[]>([]);
   const [friendRequests, setFriendRequests] = useState<FriendRequest[]>([]);
   const [receivedMessagesCount, setReceivedMessagesCount] = useState<number>(0);
   const [isLoading, setIsLoading] = useState(true);
@@ -116,6 +124,7 @@ export default function MyHome() {
           fetchFriends(),
           fetchFriendRequests(),
           fetchReceivedMessagesCount(),
+          fetchGroups(),
         ]);
       } catch {
         setError('데이터를 불러오는데 실패했습니다.');
@@ -198,6 +207,21 @@ export default function MyHome() {
 
   // 현재 표시할 일정 목록
   const displaySchedules = showAllSchedules ? allSchedules : recentSchedules;
+
+  // 그룹 조회
+  const fetchGroups = async () => {
+    try {
+      const token = getCookieValue('accessToken');
+      const response = await axiosInstance.get('/api/groups/mygroups', {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+      setGroups(response.data);
+    } catch (err) {
+      console.error('그룹 목록 조회 실패:', err);
+    }
+  };
 
   return (
     <div className="my-home-page py-4 px-4 pt-20 pb-20 mx-auto rounded-lg bg-gray-100 overflow-y-auto">
@@ -296,9 +320,24 @@ export default function MyHome() {
 
       <div className="my-groups bg-white p-4 rounded-lg shadow-sm">
         <h3 className="text-lg font-semibold mb-2">내 그룹 목록</h3>
-        <div className="group-item bg-gray-200 p-3 rounded mb-2">그룹1</div>
-        <div className="group-item bg-gray-200 p-3 rounded mb-2">그룹2</div>
-        <div className="group-item bg-gray-200 p-3 rounded">그룹3</div>
+        {groups.length === 0 ? (
+          <p className="text-gray-500">가입된 그룹이 없습니다.</p>
+        ) : (
+          groups.slice(0, 3).map((group) => (
+            <div
+              key={group.groupId}
+              className="group-item bg-gray-200 p-3 rounded mb-2 cursor-pointer hover:bg-gray-300 transition-colors"
+              onClick={() =>
+                router.push(
+                  `/front/my-home/group/detail?groupId=${group.groupId}`
+                )
+              }
+            >
+              <div className="font-medium text-gray-800">{group.groupName}</div>
+              {/* <div className="text-sm text-gray-600">{group.description}</div> */}
+            </div>
+          ))
+        )}
 
         <Button
           type="button"


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolves: https://github.com/DdNnTt/Chingu-Frontend/issues/86

## 📝작업 내용
- 그룹 생성, 그룹 상세 페이지에 뒤로가기 버튼 추가  
- 독바(Dockbar)에서 /group, /member 경로 접근 시 '그룹' 탭 활성화 표시되도록 수정  
- pathname.includes() 기반 isActive 조건 적용  

## 스크린샷 (선택)

## 💬리뷰 요구사항(선택)