### PR TITLE
메시지 조회 및 리스트 API 연동

### DIFF
--- a/src/app/front/components/layout/Dockbar/page.tsx
+++ b/src/app/front/components/layout/Dockbar/page.tsx
@@ -24,7 +24,7 @@ export default function Dockbar() {
       label: '마이페이지',
       icon: <UserCircle size={20} />,
     },
-    { href: '/front/message', label: '쪽지', icon: <Mail size={20} /> },
+    { href: '/front/message/list', label: '쪽지', icon: <Mail size={20} /> },
   ];
 
   return (

--- a/src/app/front/message/detail/MessageDetail.tsx
+++ b/src/app/front/message/detail/MessageDetail.tsx
@@ -1,33 +1,228 @@
 'use client';
 
 import { useRouter, useSearchParams } from 'next/navigation';
-import Button from '@/components/common/Button';
+import { useState, useEffect } from 'react';
+
+interface Message {
+  messageId: number;
+  sender: string;
+  receiver: string;
+  content: string;
+  sendTime: string;
+  readStatus: boolean;
+  senderDeleted: boolean;
+  receiverDeleted: boolean;
+}
 
 export default function MessageDetail() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const messageId = searchParams.get('id');
+  const [message, setMessage] = useState<Message | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
 
-  const message = {
-    id: messageId,
-    sender: '닉네임1',
-    content: '쪽지 내용입니다. 테스트입니다.',
-    date: '2025.04.24',
-  };
+  useEffect(() => {
+    const fetchMessage = async () => {
+      if (!messageId) {
+        setError('쪽지 ID가 없습니다.');
+        setIsLoading(false);
+        return;
+      }
 
-  const handleDelete = () => {
+      try {
+        console.log('쪽지 조회 시작:', messageId);
+
+        // 토큰 확인
+        const token = document.cookie
+          .split('; ')
+          .find((row) => row.startsWith('accessToken='))
+          ?.split('=')[1];
+
+        console.log('토큰 존재:', !!token);
+
+        // 직접 fetch 사용 (axios 대신)
+
+        const response = await fetch(`/api/messages/read/${messageId}`, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+            ...(token && { Authorization: `Bearer ${token}` }),
+          },
+        });
+
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => ({}));
+          console.error('API 에러:', errorData);
+
+          if (
+            response.status === 500 &&
+            errorData.message === '해당 쪽지에 대한 접근 권한이 없습니다.'
+          ) {
+            throw new Error('이 쪽지에 대한 접근 권한이 없습니다.');
+          } else {
+            throw new Error(`HTTP error! status: ${response.status}`);
+          }
+        }
+
+        const data = await response.json();
+        console.log('쪽지 조회 성공:', data);
+        setMessage(data);
+
+        // 읽음 처리 (별도 try-catch로 분리)
+        try {
+          console.log('읽음 처리 시작');
+          const readResponse = await fetch(`/api/messages/read/${messageId}`, {
+            method: 'PATCH',
+            headers: {
+              'Content-Type': 'application/json',
+              ...(token && { Authorization: `Bearer ${token}` }),
+            },
+          });
+
+          if (readResponse.ok) {
+            console.log('읽음 처리 성공');
+          } else {
+            console.error('읽음 처리 실패:', readResponse.status);
+          }
+        } catch (readErr: unknown) {
+          console.error('읽음 처리 실패:', readErr);
+          // 읽음 처리 실패는 사용자에게 알리지 않음
+        }
+      } catch (err: unknown) {
+        console.error('쪽지 조회 실패:', err);
+        const errorMessage =
+          err instanceof Error ? err.message : '쪽지를 불러오지 못했습니다.';
+        setError(errorMessage);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchMessage();
+  }, [messageId]);
+
+  const handleDelete = async () => {
+    if (!messageId) return;
+
     const isConfirmed = confirm('쪽지를 삭제하시겠습니까?');
 
     if (isConfirmed) {
-      alert('해당 쪽지가 삭제되었습니다.');
-      router.push('/front/message/list');
+      try {
+        const token = document.cookie
+          .split('; ')
+          .find((row) => row.startsWith('accessToken='))
+          ?.split('=')[1];
+
+        const response = await fetch(`/api/messages/${messageId}`, {
+          method: 'DELETE',
+          headers: {
+            'Content-Type': 'application/json',
+            ...(token && { Authorization: `Bearer ${token}` }),
+          },
+        });
+
+        if (response.ok) {
+          alert('쪽지가 삭제되었습니다.');
+          router.push('/front/message/list');
+        } else {
+          throw new Error(`삭제 실패: ${response.status}`);
+        }
+      } catch (err) {
+        console.error('쪽지 삭제 실패:', err);
+        alert('쪽지 삭제에 실패했습니다.');
+      }
     }
   };
 
+  if (isLoading) {
+    return (
+      <div className="flex flex-col bg-gray-100 overflow-hidden pt-20">
+        <div className="bg-white p-4 flex items-center border-b">
+          <button
+            onClick={() => router.back()}
+            className="flex items-center gap-2 px-3 py-2 text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded-lg transition-colors"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 19l-7-7 7-7"
+              />
+            </svg>
+            뒤로
+          </button>
+          <h1 className="text-center flex-1 font-semibold">쪽지 상세</h1>
+          <div className="w-10"></div>
+        </div>
+        <div className="flex-1 p-4 flex items-center justify-center">
+          <div className="text-gray-500">쪽지를 불러오는 중...</div>
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !message) {
+    return (
+      <div className="flex flex-col bg-gray-100 overflow-hidden pt-20">
+        <div className="bg-white p-4 flex items-center border-b">
+          <button
+            onClick={() => router.back()}
+            className="flex items-center gap-2 px-3 py-2 text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded-lg transition-colors"
+          >
+            <svg
+              className="w-5 h-5"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 19l-7-7 7-7"
+              />
+            </svg>
+            뒤로
+          </button>
+          <h1 className="text-center flex-1 font-semibold">쪽지 상세</h1>
+          <div className="w-10"></div>
+        </div>
+        <div className="flex-1 p-4 flex items-center justify-center">
+          <div className="text-red-500">
+            {error || '쪽지를 찾을 수 없습니다.'}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
-    <div className="flex flex-col bg-gray-100 overflow-hidden">
+    <div className="flex flex-col bg-gray-100 overflow-hidden pt-20 pb-20">
       <div className="bg-white p-4 flex items-center border-b">
-        <button onClick={() => router.back()} className="text-gray-600">
+        <button
+          onClick={() => router.back()}
+          className="flex items-center gap-2 px-3 py-2 text-gray-600 hover:text-gray-800 hover:bg-gray-100 rounded-lg transition-colors"
+        >
+          <svg
+            className="w-5 h-5"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M15 19l-7-7 7-7"
+            />
+          </svg>
           뒤로
         </button>
         <h1 className="text-center flex-1 font-semibold">
@@ -38,30 +233,37 @@ export default function MessageDetail() {
 
       <div className="flex-1 p-4">
         <div className="bg-white rounded-lg p-4 min-h-[200px]">
-          <div className="text-sm text-gray-400 mb-2">{message.date}</div>
+          <div className="text-sm text-gray-400 mb-2">
+            {new Date(message.sendTime).toLocaleString()}
+          </div>
           <div className="text-gray-800 whitespace-pre-line">
             {message.content}
           </div>
+          {!message.readStatus && (
+            <div className="mt-2">
+              <span className="bg-red-100 text-red-700 px-2 py-1 rounded-full text-xs">
+                읽지 않음
+              </span>
+            </div>
+          )}
         </div>
       </div>
 
       <div className="bg-white p-4 flex gap-2 border-t">
-        <Button
+        <button
           type="button"
-          variant="secondary"
-          className="flex-1"
-          onClick={handleDelete}
-        >
-          삭제
-        </Button>
-        <Button
-          type="button"
-          variant="primary"
-          className="flex-1"
+          className="flex-1 bg-gray-500 text-white py-3 px-4 rounded-lg font-medium"
           onClick={() => router.push('/front/message/list')}
         >
           목록
-        </Button>
+        </button>
+        <button
+          type="button"
+          className="flex-1 bg-main-color text-white py-3 px-4 rounded-lg font-medium"
+          onClick={handleDelete}
+        >
+          삭제
+        </button>
       </div>
     </div>
   );

--- a/src/app/front/message/detail/MessageDetail.tsx
+++ b/src/app/front/message/detail/MessageDetail.tsx
@@ -2,6 +2,8 @@
 
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useState, useEffect } from 'react';
+import axios from '@/libs/axios';
+import { isAxiosError } from 'axios';
 
 interface Message {
   messageId: number;
@@ -31,68 +33,33 @@ export default function MessageDetail() {
       }
 
       try {
-        console.log('쪽지 조회 시작:', messageId);
+        const response = await axios.get(`/api/messages/read/${messageId}`);
+        setMessage(response.data);
 
-        // 토큰 확인
-        const token = document.cookie
-          .split('; ')
-          .find((row) => row.startsWith('accessToken='))
-          ?.split('=')[1];
-
-        console.log('토큰 존재:', !!token);
-
-        // 직접 fetch 사용 (axios 대신)
-
-        const response = await fetch(`/api/messages/read/${messageId}`, {
-          method: 'GET',
-          headers: {
-            'Content-Type': 'application/json',
-            ...(token && { Authorization: `Bearer ${token}` }),
-          },
-        });
-
-        if (!response.ok) {
-          const errorData = await response.json().catch(() => ({}));
-          console.error('API 에러:', errorData);
-
-          if (
-            response.status === 500 &&
-            errorData.message === '해당 쪽지에 대한 접근 권한이 없습니다.'
-          ) {
-            throw new Error('이 쪽지에 대한 접근 권한이 없습니다.');
-          } else {
-            throw new Error(`HTTP error! status: ${response.status}`);
-          }
-        }
-
-        const data = await response.json();
-        console.log('쪽지 조회 성공:', data);
-        setMessage(data);
-
-        // 읽음 처리 (별도 try-catch로 분리)
         try {
-          console.log('읽음 처리 시작');
-          const readResponse = await fetch(`/api/messages/read/${messageId}`, {
-            method: 'PATCH',
-            headers: {
-              'Content-Type': 'application/json',
-              ...(token && { Authorization: `Bearer ${token}` }),
-            },
-          });
-
-          if (readResponse.ok) {
-            console.log('읽음 처리 성공');
-          } else {
-            console.error('읽음 처리 실패:', readResponse.status);
-          }
-        } catch (readErr: unknown) {
-          console.error('읽음 처리 실패:', readErr);
+          await axios.patch(`/api/messages/read/${messageId}`);
+        } catch {
           // 읽음 처리 실패는 사용자에게 알리지 않음
         }
       } catch (err: unknown) {
-        console.error('쪽지 조회 실패:', err);
-        const errorMessage =
-          err instanceof Error ? err.message : '쪽지를 불러오지 못했습니다.';
+        let errorMessage = '쪽지를 불러오지 못했습니다.';
+
+        if (isAxiosError(err)) {
+          if (
+            err.response?.status === 500 &&
+            err.response?.data?.message ===
+              '해당 쪽지에 대한 접근 권한이 없습니다.'
+          ) {
+            errorMessage = '이 쪽지에 대한 접근 권한이 없습니다.';
+          } else {
+            errorMessage =
+              (err.response?.data as { message?: string })?.message ||
+              errorMessage;
+          }
+        } else if (err instanceof Error) {
+          errorMessage = err.message;
+        }
+
         setError(errorMessage);
       } finally {
         setIsLoading(false);
@@ -109,27 +76,10 @@ export default function MessageDetail() {
 
     if (isConfirmed) {
       try {
-        const token = document.cookie
-          .split('; ')
-          .find((row) => row.startsWith('accessToken='))
-          ?.split('=')[1];
-
-        const response = await fetch(`/api/messages/${messageId}`, {
-          method: 'DELETE',
-          headers: {
-            'Content-Type': 'application/json',
-            ...(token && { Authorization: `Bearer ${token}` }),
-          },
-        });
-
-        if (response.ok) {
-          alert('쪽지가 삭제되었습니다.');
-          router.push('/front/message/list');
-        } else {
-          throw new Error(`삭제 실패: ${response.status}`);
-        }
-      } catch (err) {
-        console.error('쪽지 삭제 실패:', err);
+        await axios.delete(`/api/messages/${messageId}`);
+        alert('쪽지가 삭제되었습니다.');
+        router.push('/front/message/list');
+      } catch {
         alert('쪽지 삭제에 실패했습니다.');
       }
     }

--- a/src/app/front/message/detail/MessageDetail.tsx
+++ b/src/app/front/message/detail/MessageDetail.tsx
@@ -4,6 +4,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { useState, useEffect } from 'react';
 import axios from '@/libs/axios';
 import { isAxiosError } from 'axios';
+import Button from '@/components/common/Button';
 
 interface Message {
   messageId: number;
@@ -200,20 +201,16 @@ export default function MessageDetail() {
       </div>
 
       <div className="bg-white p-4 flex gap-2 border-t">
-        <button
-          type="button"
-          className="flex-1 bg-gray-500 text-white py-3 px-4 rounded-lg font-medium"
+        <Button
+          variant="secondary"
+          className="flex-1"
           onClick={() => router.push('/front/message/list')}
         >
           목록
-        </button>
-        <button
-          type="button"
-          className="flex-1 bg-main-color text-white py-3 px-4 rounded-lg font-medium"
-          onClick={handleDelete}
-        >
+        </Button>
+        <Button variant="primary" className="flex-1" onClick={handleDelete}>
           삭제
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/src/app/front/message/list/page.tsx
+++ b/src/app/front/message/list/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import axios from '@/libs/axios';
+import axiosInstance from '@/libs/axios';
 
 interface Message {
   messageId: number;
@@ -27,10 +27,10 @@ export default function MessageList() {
       setIsLoading(true);
       try {
         if (activeTab === 'sent') {
-          const res = await axios.get('/api/messages/sent');
+          const res = await axiosInstance.get('/api/messages/sent');
           setSentMessages(res.data);
         } else {
-          const res = await axios.get('/api/messages/read/all');
+          const res = await axiosInstance.get('/api/messages/read/all');
           setReceivedMessages(res.data);
         }
       } catch {


### PR DESCRIPTION
## #️⃣연관된 이슈

- resolves: https://github.com/DdNnTt/Chingu-Frontend/issues/94

## 📝작업 내용

- 메시지 조회 API 개선 - 쪽지 상세 조회 및 읽음 처리 기능 강화
- 쪽지 리스트 API - 쪽지 목록 조회 UI 및 기능 개선
- 독바 네비게이션 - 쪽지 아이콘 클릭 시 쪽지 리스트로 이동하도록 변경

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
