### PR TITLE
추억 앨범 삭제 API 연동

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,14 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-    domains: ['chingu-album.s3.ap-northeast-2.amazonaws.com'],
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'chingu-album.s3.ap-northeast-2.amazonaws.com',
+        port: '',
+        pathname: '/**',
+      },
+    ],
   },
   async rewrites() {
     const apiBaseUrl = process.env.API_BASE_URL;

--- a/src/app/api/groups/[groupId]/albums/[memoryId]/route.ts
+++ b/src/app/api/groups/[groupId]/albums/[memoryId]/route.ts
@@ -1,0 +1,123 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ groupId: string; memoryId: string }> }
+) {
+  const token = req.headers.get('authorization');
+  const API_BASE = process.env.API_BASE_URL;
+  const { groupId, memoryId } = await params;
+
+  if (!API_BASE) {
+    return NextResponse.json({ message: 'API 주소 누락' }, { status: 500 });
+  }
+
+  if (!groupId || !memoryId) {
+    return NextResponse.json(
+      { message: 'groupId 또는 memoryId 누락' },
+      { status: 400 }
+    );
+  }
+
+  try {
+    console.log('[앨범 상세 프록시] 요청 데이터:', {
+      groupId,
+      memoryId,
+      token: token ? `${token.substring(0, 20)}...` : 'null',
+      API_BASE,
+    });
+
+    const res = await fetch(
+      `${API_BASE}/api/groups/${groupId}/albums/${memoryId}`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: token ?? '',
+        },
+      }
+    );
+
+    console.log('[앨범 상세 프록시] 백엔드 응답:', {
+      status: res.status,
+      statusText: res.statusText,
+      headers: Object.fromEntries(res.headers.entries()),
+    });
+
+    const text = await res.text();
+    console.log('[앨범 상세 프록시] 백엔드 응답 텍스트:', text);
+
+    try {
+      const data = JSON.parse(text);
+      console.log('[앨범 상세 프록시] 파싱된 응답 데이터:', data);
+      return NextResponse.json(data, { status: res.status });
+    } catch (parseError) {
+      console.error('[앨범 상세 프록시] JSON 파싱 실패:', parseError);
+      return NextResponse.json({ message: text }, { status: res.status });
+    }
+  } catch (err) {
+    console.error('[앨범 상세 프록시 GET 오류]', err);
+    return NextResponse.json({ message: '서버 오류' }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ groupId: string; memoryId: string }> }
+) {
+  const token = req.headers.get('authorization');
+  const API_BASE = process.env.API_BASE_URL;
+  const { groupId, memoryId } = await params;
+
+  if (!API_BASE) {
+    return NextResponse.json({ message: 'API 주소 누락' }, { status: 500 });
+  }
+
+  if (!groupId || !memoryId) {
+    return NextResponse.json(
+      { message: 'groupId 또는 memoryId 누락' },
+      { status: 400 }
+    );
+  }
+
+  try {
+    console.log('[앨범 삭제 프록시] 요청 데이터:', {
+      groupId,
+      memoryId,
+      token: token ? `${token.substring(0, 20)}...` : 'null',
+      API_BASE,
+    });
+
+    const res = await fetch(
+      `${API_BASE}/api/groups/${groupId}/albums/${memoryId}`,
+      {
+        method: 'DELETE',
+        headers: {
+          Authorization: token ?? '',
+        },
+      }
+    );
+
+    console.log('[앨범 삭제 프록시] 백엔드 응답:', {
+      status: res.status,
+      statusText: res.statusText,
+      headers: Object.fromEntries(res.headers.entries()),
+    });
+
+    const text = await res.text();
+    console.log('[앨범 삭제 프록시] 백엔드 응답 텍스트:', text);
+
+    try {
+      const data = JSON.parse(text);
+      console.log('[앨범 삭제 프록시] 파싱된 응답 데이터:', data);
+      return NextResponse.json(data, { status: res.status });
+    } catch (parseError) {
+      console.error('[앨범 삭제 프록시] JSON 파싱 실패:', parseError);
+      return NextResponse.json({ message: text }, { status: res.status });
+    }
+  } catch (err) {
+    console.error('[앨범 삭제 프록시 DELETE 오류]', err);
+    return NextResponse.json({ message: '서버 오류' }, { status: 500 });
+  }
+}

--- a/src/app/api/groups/[groupId]/albums/[memoryId]/route.ts
+++ b/src/app/api/groups/[groupId]/albums/[memoryId]/route.ts
@@ -62,6 +62,70 @@ export async function GET(
   }
 }
 
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ groupId: string; memoryId: string }> }
+) {
+  const token = req.headers.get('authorization');
+  const API_BASE = process.env.API_BASE_URL;
+  const { groupId, memoryId } = await params;
+
+  if (!API_BASE) {
+    return NextResponse.json({ message: 'API 주소 누락' }, { status: 500 });
+  }
+
+  if (!groupId || !memoryId) {
+    return NextResponse.json(
+      { message: 'groupId 또는 memoryId 누락' },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const body = await req.json();
+    console.log('[앨범 수정 프록시] 요청 데이터:', {
+      groupId,
+      memoryId,
+      body,
+      token: token ? `${token.substring(0, 20)}...` : 'null',
+      API_BASE,
+    });
+
+    const res = await fetch(
+      `${API_BASE}/api/groups/${groupId}/albums/${memoryId}`,
+      {
+        method: 'PATCH',
+        headers: {
+          Authorization: token ?? '',
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(body),
+      }
+    );
+
+    console.log('[앨범 수정 프록시] 백엔드 응답:', {
+      status: res.status,
+      statusText: res.statusText,
+      headers: Object.fromEntries(res.headers.entries()),
+    });
+
+    const text = await res.text();
+    console.log('[앨범 수정 프록시] 백엔드 응답 텍스트:', text);
+
+    try {
+      const data = JSON.parse(text);
+      console.log('[앨범 수정 프록시] 파싱된 응답 데이터:', data);
+      return NextResponse.json(data, { status: res.status });
+    } catch (parseError) {
+      console.error('[앨범 수정 프록시] JSON 파싱 실패:', parseError);
+      return NextResponse.json({ message: text }, { status: res.status });
+    }
+  } catch (err) {
+    console.error('[앨범 수정 프록시 PATCH 오류]', err);
+    return NextResponse.json({ message: '서버 오류' }, { status: 500 });
+  }
+}
+
 export async function DELETE(
   req: NextRequest,
   { params }: { params: Promise<{ groupId: string; memoryId: string }> }

--- a/src/app/api/groups/[groupId]/albums/[memoryId]/route.ts
+++ b/src/app/api/groups/[groupId]/albums/[memoryId]/route.ts
@@ -33,9 +33,7 @@ export async function GET(
       `${API_BASE}/api/groups/${groupId}/albums/${memoryId}`,
       {
         method: 'GET',
-        headers: {
-          Authorization: token ?? '',
-        },
+        headers: token ? { Authorization: token } : {},
       }
     );
 
@@ -96,7 +94,7 @@ export async function PATCH(
       {
         method: 'PATCH',
         headers: {
-          Authorization: token ?? '',
+          ...(token ? { Authorization: token } : {}),
           'Content-Type': 'application/json',
         },
         body: JSON.stringify(body),
@@ -157,9 +155,7 @@ export async function DELETE(
       `${API_BASE}/api/groups/${groupId}/albums/${memoryId}`,
       {
         method: 'DELETE',
-        headers: {
-          Authorization: token ?? '',
-        },
+        headers: token ? { Authorization: token } : {},
       }
     );
 

--- a/src/app/api/users/[userId]/route.ts
+++ b/src/app/api/users/[userId]/route.ts
@@ -16,9 +16,7 @@ export async function GET(
   try {
     const res = await fetch(`${API_BASE}/api/users/${userId}`, {
       method: 'GET',
-      headers: {
-        Authorization: token || '',
-      },
+      headers: token ? { Authorization: token } : {},
     });
 
     if (!res.ok) {

--- a/src/app/front/my-home/friend-list/page.tsx
+++ b/src/app/front/my-home/friend-list/page.tsx
@@ -51,7 +51,7 @@ export default function FriendListPage() {
           {friends.map((friend) => (
             <li
               key={friend.friendUserId}
-              className="flex items-center justify-between bg-white border rounded-lg shadow-sm px-4 py-3 hover:bg-blue-50 transition"
+              className="flex items-center justify-between bg-white border rounded-lg shadow-sm px-4 py-3 hover:bg-[#aa96fc] hover:bg-opacity-10 transition"
             >
               <div>
                 <span className="font-semibold text-lg">{friend.nickname}</span>
@@ -65,7 +65,7 @@ export default function FriendListPage() {
               </div>
               <Link
                 href={`/front/my-home/friend/${friend.friendUserId}`}
-                className="text-blue-600 hover:underline text-sm font-medium"
+                className="main-color hover:underline text-sm font-medium"
               >
                 프로필
               </Link>

--- a/src/app/front/my-home/friend-requests/page.tsx
+++ b/src/app/front/my-home/friend-requests/page.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import axiosInstance from '@/libs/axios';
 import Link from 'next/link';
-import Button from '@/components/common/Button';
 import { AxiosError } from 'axios';
 
 interface FriendRequest {
@@ -134,30 +133,30 @@ export default function FriendRequestsPage() {
                 </div>
               </div>
               <div className="flex gap-3">
-                <Button
+                <button
                   type="button"
                   onClick={() => handleRespond(request.fromUserId, 'accepted')}
                   disabled={responding === request.fromUserId}
-                  className={`text-white text-sm px-4 py-2 rounded-lg font-medium transition-all duration-200 ${
+                  className={`text-white text-sm px-4 py-2 rounded-lg font-medium transition-all duration-300 hover:scale-105 active:scale-95 ${
                     responding === request.fromUserId
                       ? 'bg-gray-400 cursor-not-allowed opacity-70'
-                      : 'bg-main-color hover:bg-sub-color hover:shadow-md transform hover:scale-105'
+                      : 'bg-[#9477ff] hover:bg-[#6845f5] hover:shadow-md'
                   }`}
                 >
-                  {responding === request.fromUserId ? '처리중...' : '수락'}
-                </Button>
-                <Button
+                  수락
+                </button>
+                <button
                   type="button"
                   onClick={() => handleRespond(request.fromUserId, 'rejected')}
                   disabled={responding === request.fromUserId}
-                  className={`text-sm px-4 py-2 rounded-lg font-medium transition-all duration-200 border ${
+                  className={`text-sm px-4 py-2 rounded-lg font-medium transition-all duration-300 hover:scale-105 active:scale-95 border ${
                     responding === request.fromUserId
                       ? 'bg-gray-100 text-gray-400 border-gray-300 cursor-not-allowed opacity-70'
-                      : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50 hover:border-gray-400 hover:shadow-md transform hover:scale-105'
+                      : 'bg-white text-gray-700 border-gray-300 hover:bg-gray-50 hover:border-gray-400 hover:shadow-md'
                   }`}
                 >
-                  {responding === request.fromUserId ? '처리중...' : '거절'}
-                </Button>
+                  거절
+                </button>
               </div>
             </li>
           ))}

--- a/src/app/front/my-home/friend/[friendId]/page.tsx
+++ b/src/app/front/my-home/friend/[friendId]/page.tsx
@@ -73,10 +73,7 @@ export default function FriendDetailPage() {
   const fetchUserInfo = useCallback(async () => {
     try {
       setLoading(true);
-      console.log('[친구 상세] 사용자 정보 조회 시작:', friendId);
-
       const response = await axiosInstance.get(`/api/users/${friendId}`);
-      console.log('[친구 상세] 사용자 정보 조회 성공:', response.data);
 
       if (response.status === 404) {
         setError('해당 사용자를 찾을 수 없습니다.');
@@ -90,22 +87,11 @@ export default function FriendDetailPage() {
       // 친구 관계 확인
       await checkFriendStatus(userData.id);
     } catch (err) {
-      console.error('[친구 상세] 사용자 정보 조회 실패:', err);
-
       if (axios.isAxiosError(err)) {
-        console.error('[친구 상세] Axios 에러 상세:', {
-          status: err.response?.status,
-          statusText: err.response?.statusText,
-          data: err.response?.data,
-          message: err.message,
-        });
-
         if (err.response?.status === 404) {
           setError('해당 사용자를 찾을 수 없습니다.');
         } else {
-          setError(
-            `사용자 정보를 불러오는데 실패했습니다. (${err.response?.status})`
-          );
+          setError('사용자 정보를 불러오는데 실패했습니다.');
         }
       } else {
         setError('오류가 발생했습니다.');

--- a/src/app/front/my-home/friend/[friendId]/page.tsx
+++ b/src/app/front/my-home/friend/[friendId]/page.tsx
@@ -73,7 +73,10 @@ export default function FriendDetailPage() {
   const fetchUserInfo = useCallback(async () => {
     try {
       setLoading(true);
+      console.log('[친구 상세] 사용자 정보 조회 시작:', friendId);
+
       const response = await axiosInstance.get(`/api/users/${friendId}`);
+      console.log('[친구 상세] 사용자 정보 조회 성공:', response.data);
 
       if (response.status === 404) {
         setError('해당 사용자를 찾을 수 없습니다.');
@@ -87,11 +90,22 @@ export default function FriendDetailPage() {
       // 친구 관계 확인
       await checkFriendStatus(userData.id);
     } catch (err) {
+      console.error('[친구 상세] 사용자 정보 조회 실패:', err);
+
       if (axios.isAxiosError(err)) {
+        console.error('[친구 상세] Axios 에러 상세:', {
+          status: err.response?.status,
+          statusText: err.response?.statusText,
+          data: err.response?.data,
+          message: err.message,
+        });
+
         if (err.response?.status === 404) {
           setError('해당 사용자를 찾을 수 없습니다.');
         } else {
-          setError('사용자 정보를 불러오는데 실패했습니다.');
+          setError(
+            `사용자 정보를 불러오는데 실패했습니다. (${err.response?.status})`
+          );
         }
       } else {
         setError('오류가 발생했습니다.');
@@ -113,7 +127,7 @@ export default function FriendDetailPage() {
       fetchFriendQuizzes();
       fetchFriendshipScore();
     }
-  }, [friendSince, user]);
+  }, [friendSince, user, fetchFriendQuizzes, fetchFriendshipScore]);
 
   // 친구 관계 확인 함수
   const checkFriendStatus = async (targetUserId: number) => {

--- a/src/app/front/my-home/group/album/albumList/page.tsx
+++ b/src/app/front/my-home/group/album/albumList/page.tsx
@@ -7,15 +7,17 @@ import { getCookieValue } from '@/utils/cookie';
 import Image from 'next/image';
 
 type Album = {
-  memoryId: number;
-  description: string;
+  albumId: number;
+  albumTitle: string;
+  albumImage?: string;
+  createdAt: string;
+  // 호환성을 위한 추가 필드들
+  memoryId?: number;
+  description?: string;
   imageUrl?: string;
   title?: string;
   content?: string;
   location?: string;
-  createdAt?: string;
-  // 백엔드에서 사용할 가능성이 높은 필드들
-  albumTitle?: string;
   albumName?: string;
   memoryTitle?: string;
   albumContent?: string;
@@ -62,20 +64,6 @@ function AlbumListContent() {
           if (!Array.isArray(data))
             throw new Error('응답 데이터가 배열이 아닙니다.');
           console.log('[앨범 목록] API 응답 데이터:', data);
-          console.log('[앨범 목록] 첫 번째 앨범 구조:', data[0]);
-          if (data[0]) {
-            console.log(
-              '[앨범 목록] 첫 번째 앨범의 모든 키:',
-              Object.keys(data[0])
-            );
-            console.log('[앨범 목록] 제목 관련 필드들:', {
-              title: data[0].title,
-              albumTitle: data[0].albumTitle,
-              memoryTitle: data[0].memoryTitle,
-              albumName: data[0].albumName,
-              name: data[0].name,
-            });
-          }
           setAlbums(data);
         } catch (err) {
           console.error('[앨범 조회 오류]', err);
@@ -117,6 +105,7 @@ function AlbumListContent() {
       </div>
 
       {/* 추억 앨범 리스트 */}
+
       <div className="bg-white p-4 rounded-md shadow mb-4">
         <div className="flex justify-between items-center mb-4">
           <h1 className="text-xl font-bold">추억 앨범</h1>
@@ -142,11 +131,11 @@ function AlbumListContent() {
             {albums.map((album) => {
               return (
                 <div
-                  key={album.memoryId}
+                  key={album.albumId || album.memoryId}
                   className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden cursor-pointer hover:shadow-md transition-shadow"
                   onClick={() => {
                     router.push(
-                      `/front/my-home/group/album/detail?groupId=${groupId}&albumId=${album.memoryId}`
+                      `/front/my-home/group/album/detail?groupId=${groupId}&albumId=${album.albumId || album.memoryId}`
                     );
                   }}
                 >
@@ -172,7 +161,7 @@ function AlbumListContent() {
                             strokeLinecap="round"
                             strokeLinejoin="round"
                             strokeWidth={2}
-                            d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+                            d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2 2v12a2 2 0 002 2z"
                           />
                         </svg>
                       </div>
@@ -182,13 +171,9 @@ function AlbumListContent() {
                   {/* 앨범 정보 */}
                   <div className="p-3">
                     {/* 제목 */}
-                    <h3 className="text-sm font-semibold text-gray-900 mb-1 line-clamp-1">
-                      {album.title ||
-                        album.albumTitle ||
-                        album.memoryTitle ||
-                        album.albumName ||
-                        `앨범 #${album.memoryId}`}
-                    </h3>
+                    {/* <h3 className="text-sm font-semibold text-gray-900 mb-1 line-clamp-1">
+                      {album.albumTitle || `앨범 #${album.albumId}`}
+                    </h3> */}
 
                     {/* 설명 */}
                     <p className="text-xs text-gray-600 mb-2 line-clamp-2">

--- a/src/app/front/my-home/group/album/albumList/page.tsx
+++ b/src/app/front/my-home/group/album/albumList/page.tsx
@@ -10,6 +10,18 @@ type Album = {
   memoryId: number;
   description: string;
   imageUrl?: string;
+  title?: string;
+  content?: string;
+  location?: string;
+  createdAt?: string;
+  // 백엔드에서 사용할 가능성이 높은 필드들
+  albumTitle?: string;
+  albumName?: string;
+  memoryTitle?: string;
+  albumContent?: string;
+  memoryContent?: string;
+  albumLocation?: string;
+  memoryLocation?: string;
 };
 
 function AlbumListContent() {
@@ -49,6 +61,21 @@ function AlbumListContent() {
           if (!res.ok) throw new Error(data.message || '앨범 조회 실패');
           if (!Array.isArray(data))
             throw new Error('응답 데이터가 배열이 아닙니다.');
+          console.log('[앨범 목록] API 응답 데이터:', data);
+          console.log('[앨범 목록] 첫 번째 앨범 구조:', data[0]);
+          if (data[0]) {
+            console.log(
+              '[앨범 목록] 첫 번째 앨범의 모든 키:',
+              Object.keys(data[0])
+            );
+            console.log('[앨범 목록] 제목 관련 필드들:', {
+              title: data[0].title,
+              albumTitle: data[0].albumTitle,
+              memoryTitle: data[0].memoryTitle,
+              albumName: data[0].albumName,
+              name: data[0].name,
+            });
+          }
           setAlbums(data);
         } catch (err) {
           console.error('[앨범 조회 오류]', err);
@@ -118,7 +145,9 @@ function AlbumListContent() {
                   key={album.memoryId}
                   className="bg-white rounded-lg shadow-sm border border-gray-200 overflow-hidden cursor-pointer hover:shadow-md transition-shadow"
                   onClick={() => {
-                    // TODO: 앨범 상세 페이지로 이동
+                    router.push(
+                      `/front/my-home/group/album/detail?groupId=${groupId}&albumId=${album.memoryId}`
+                    );
                   }}
                 >
                   {/* 이미지 영역 */}
@@ -152,9 +181,55 @@ function AlbumListContent() {
 
                   {/* 앨범 정보 */}
                   <div className="p-3">
-                    <p className="text-sm text-gray-800 mb-2 line-clamp-2">
-                      {album.description || '내용 없음'}
+                    {/* 제목 */}
+                    <h3 className="text-sm font-semibold text-gray-900 mb-1 line-clamp-1">
+                      {album.title ||
+                        album.albumTitle ||
+                        album.memoryTitle ||
+                        album.albumName ||
+                        `앨범 #${album.memoryId}`}
+                    </h3>
+
+                    {/* 설명 */}
+                    <p className="text-xs text-gray-600 mb-2 line-clamp-2">
+                      {album.content ||
+                        album.albumContent ||
+                        album.memoryContent ||
+                        album.description ||
+                        '내용 없음'}
                     </p>
+
+                    {/* 위치 */}
+                    {(album.location ||
+                      album.albumLocation ||
+                      album.memoryLocation) && (
+                      <div className="flex items-center gap-1 text-xs text-gray-500">
+                        <svg
+                          className="w-3 h-3"
+                          fill="none"
+                          stroke="currentColor"
+                          viewBox="0 0 24 24"
+                        >
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
+                          />
+                          <path
+                            strokeLinecap="round"
+                            strokeLinejoin="round"
+                            strokeWidth={2}
+                            d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
+                          />
+                        </svg>
+                        <span className="line-clamp-1">
+                          {album.location ||
+                            album.albumLocation ||
+                            album.memoryLocation}
+                        </span>
+                      </div>
+                    )}
                   </div>
                 </div>
               );

--- a/src/app/front/my-home/group/album/detail/page.tsx
+++ b/src/app/front/my-home/group/album/detail/page.tsx
@@ -1,0 +1,373 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import React, { useState, useEffect, Suspense } from 'react';
+import Image from 'next/image';
+import { getCookieValue } from '@/utils/cookie';
+
+type AlbumDetail = {
+  memoryId: number;
+  description: string;
+  imageUrl?: string;
+  createdAt?: string;
+  // 추가 필드들 (실제 API 응답에 따라)
+  title?: string;
+  albumTitle?: string;
+  content?: string;
+  albumContent?: string;
+  location?: string;
+  albumLocation?: string;
+  memoryDate?: string;
+  albumImage?: string;
+  albumImage2?: string;
+  albumImage3?: string;
+  // 기타 가능한 필드들
+  name?: string;
+  place?: string;
+  address?: string;
+  // 백엔드에서 사용할 가능성이 높은 필드들
+  albumName?: string;
+  memoryTitle?: string;
+  memoryContent?: string;
+  memoryLocation?: string;
+};
+
+function AlbumDetailContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const groupId = searchParams.get('groupId');
+  const albumId = searchParams.get('albumId');
+
+  const [albumDetail, setAlbumDetail] = useState<AlbumDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  // 토큰 상태 확인
+  const accessToken = getCookieValue('accessToken');
+
+  useEffect(() => {
+    if (!groupId || !albumId || !accessToken) {
+      setError('필요한 정보가 없습니다.');
+      setLoading(false);
+      return;
+    }
+
+    const fetchAlbumDetail = async () => {
+      try {
+        // 앨범 상세 정보 조회
+        const response = await fetch(`/api/groups/${groupId}/albums`, {
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        });
+
+        if (response.ok) {
+          const albums = await response.json();
+          console.log('[앨범 상세] API 응답:', albums);
+          console.log('[앨범 상세] 찾는 albumId:', albumId);
+
+          const album = albums.find(
+            (a: AlbumDetail) => String(a.memoryId) === String(albumId)
+          );
+
+          if (album) {
+            console.log('[앨범 상세] 찾은 앨범:', album);
+            setAlbumDetail(album);
+          } else {
+            console.log(
+              '[앨범 상세] 앨범을 찾을 수 없음. 사용 가능한 앨범들:',
+              albums.map((a: AlbumDetail) => ({
+                memoryId: a.memoryId,
+                description: a.description,
+              }))
+            );
+            setError('앨범을 찾을 수 없습니다.');
+          }
+        } else {
+          setError('앨범 정보를 불러오는데 실패했습니다.');
+        }
+      } catch (err) {
+        console.error('[앨범 상세 조회 오류]', err);
+        setError('앨범 정보를 불러오는데 실패했습니다.');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchAlbumDetail();
+  }, [groupId, albumId, accessToken]);
+
+  // 날짜 포맷팅
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return date.toLocaleDateString('ko-KR', {
+      year: 'numeric',
+      month: 'long',
+      day: 'numeric',
+    });
+  };
+
+  // 이미지 URL 배열 생성
+  const getImageUrls = (album: AlbumDetail) => {
+    const urls = [];
+    // 기본 imageUrl 필드 확인
+    if (album.imageUrl) urls.push(album.imageUrl);
+    // 추가 이미지 필드들 확인
+    if (album.albumImage) urls.push(album.albumImage);
+    if (album.albumImage2) urls.push(album.albumImage2);
+    if (album.albumImage3) urls.push(album.albumImage3);
+    return urls;
+  };
+
+  // 로딩 상태
+  if (loading) {
+    return (
+      <div className="group-detail-page h-screen flex flex-col py-4 px-4 pt-20 mx-auto rounded-lg bg-gray-100">
+        <div className="flex items-center mb-6">
+          <button
+            onClick={() => router.back()}
+            className="text-gray-600 hover:text-gray-800"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={2}
+              stroke="currentColor"
+              className="w-6 h-6"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18"
+              />
+            </svg>
+          </button>
+          <h2 className="text-2xl font-semibold text-center flex-1">
+            앨범 상세
+          </h2>
+        </div>
+        <div className="flex-1 flex items-center justify-center">
+          <div className="text-center">
+            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-[#9477ff] mx-auto mb-4"></div>
+            <p className="text-gray-600">앨범 정보를 불러오는 중...</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // 에러 상태
+  if (error || !albumDetail) {
+    return (
+      <div className="group-detail-page h-screen flex flex-col py-4 px-4 pt-20 mx-auto rounded-lg bg-gray-100">
+        <div className="flex items-center mb-6">
+          <button
+            onClick={() => router.back()}
+            className="text-gray-600 hover:text-gray-800"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={2}
+              stroke="currentColor"
+              className="w-6 h-6"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18"
+              />
+            </svg>
+          </button>
+          <h2 className="text-2xl font-semibold text-center flex-1">
+            앨범 상세
+          </h2>
+        </div>
+        <div className="flex-1 flex items-center justify-center">
+          <div className="text-center">
+            <div className="text-6xl mb-4">⚠️</div>
+            <h3 className="text-xl font-semibold mb-2">
+              앨범을 찾을 수 없습니다
+            </h3>
+            <p className="text-gray-600 mb-4">{error}</p>
+            <button
+              onClick={() => router.back()}
+              className="bg-[#9477ff] hover:bg-[#6845f5] text-white px-6 py-2 rounded-lg"
+            >
+              돌아가기
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const imageUrls = getImageUrls(albumDetail);
+
+  return (
+    <div className="group-detail-page h-screen flex flex-col py-4 px-4 pt-20 mx-auto rounded-lg bg-gray-100">
+      <div className="flex items-center mb-6">
+        <button
+          onClick={() => router.back()}
+          className="text-gray-600 hover:text-gray-800"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={2}
+            stroke="currentColor"
+            className="w-6 h-6"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18"
+            />
+          </svg>
+        </button>
+        <h2 className="text-2xl font-semibold text-center flex-1">앨범 상세</h2>
+      </div>
+
+      <div className="space-y-4 flex-1 overflow-y-auto scroll-overlay pb-20">
+        {/* 제목 */}
+        <div className="mb-4 p-4 bg-white rounded-lg shadow-sm">
+          <label className="block mb-2 font-medium text-gray-700">제목</label>
+          <div className="text-lg font-semibold text-gray-900">
+            {albumDetail.title ||
+              albumDetail.albumTitle ||
+              albumDetail.memoryTitle ||
+              albumDetail.albumName ||
+              albumDetail.name ||
+              `앨범 #${albumDetail.memoryId}`}
+          </div>
+        </div>
+
+        {/* 설명 */}
+        <div className="mb-4 p-4 bg-white rounded-lg shadow-sm">
+          <label className="block mb-2 font-medium text-gray-700">설명</label>
+          <div className="text-gray-800 whitespace-pre-wrap leading-relaxed">
+            {albumDetail.content ||
+              albumDetail.albumContent ||
+              albumDetail.memoryContent ||
+              albumDetail.description}
+          </div>
+        </div>
+
+        {/* 이미지 */}
+        {imageUrls.length > 0 && (
+          <div className="mb-4 p-4 bg-white rounded-lg shadow-sm">
+            <label className="block mb-2 font-medium text-gray-700">
+              이미지 ({imageUrls.length}장)
+            </label>
+            <div className="w-full">
+              <div className="overflow-x-auto">
+                <div
+                  className="flex gap-2 py-2"
+                  style={{ width: `${imageUrls.length * 120}px` }}
+                >
+                  {imageUrls.map((imageUrl, index) => (
+                    <div
+                      key={index}
+                      className="relative flex-shrink-0 w-28 h-28"
+                    >
+                      <Image
+                        src={imageUrl}
+                        alt={`앨범 이미지 ${index + 1}`}
+                        width={112}
+                        height={112}
+                        className="w-full h-full rounded-lg object-cover border border-gray-200"
+                      />
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* 위치 */}
+        <div className="mb-4 p-4 bg-white rounded-lg shadow-sm">
+          <label className="block mb-2 font-medium text-gray-700">위치</label>
+          <div className="text-gray-800 flex items-center gap-2">
+            <svg
+              className="w-4 h-4 text-gray-500"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"
+              />
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
+              />
+            </svg>
+            <span className="text-gray-600">
+              {albumDetail.location ||
+                albumDetail.albumLocation ||
+                albumDetail.memoryLocation ||
+                albumDetail.place ||
+                albumDetail.address ||
+                '위치 정보 없음'}
+            </span>
+          </div>
+        </div>
+
+        {/* 추억 날짜 */}
+        {albumDetail.memoryDate && (
+          <div className="mb-4 p-4 bg-white rounded-lg shadow-sm">
+            <label className="block mb-2 font-medium text-gray-700">
+              추억 날짜
+            </label>
+            <div className="text-gray-800 flex items-center gap-2">
+              <svg
+                className="w-4 h-4 text-gray-500"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+                />
+              </svg>
+              {formatDate(albumDetail.memoryDate)}
+            </div>
+          </div>
+        )}
+
+        {/* 생성일 */}
+        {albumDetail.createdAt && (
+          <div className="mb-4 p-4 bg-white rounded-lg shadow-sm">
+            <label className="block mb-2 font-medium text-gray-700">
+              생성일
+            </label>
+            <div className="text-gray-600 text-sm">
+              {formatDate(albumDetail.createdAt)}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function AlbumDetail() {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <AlbumDetailContent />
+    </Suspense>
+  );
+}

--- a/src/app/front/my-home/group/album/detail/page.tsx
+++ b/src/app/front/my-home/group/album/detail/page.tsx
@@ -7,25 +7,28 @@ import { getCookieValue } from '@/utils/cookie';
 
 type AlbumDetail = {
   memoryId: number;
-  description: string;
-  imageUrl?: string;
-  createdAt?: string;
-  // 추가 필드들 (실제 API 응답에 따라)
-  title?: string;
-  albumTitle?: string;
-  content?: string;
-  albumContent?: string;
+  groupId: number;
+  nickname: string;
+  title: string;
+  content: string;
+  imageUrl1?: string;
+  imageUrl2?: string;
+  imageUrl3?: string;
   location?: string;
+  memoryDate: string;
+  createdAt: string;
+  // 호환성을 위한 추가 필드들
+  description?: string;
+  imageUrl?: string;
+  albumTitle?: string;
+  albumContent?: string;
   albumLocation?: string;
-  memoryDate?: string;
   albumImage?: string;
   albumImage2?: string;
   albumImage3?: string;
-  // 기타 가능한 필드들
   name?: string;
   place?: string;
   address?: string;
-  // 백엔드에서 사용할 가능성이 높은 필드들
   albumName?: string;
   memoryTitle?: string;
   memoryContent?: string;
@@ -41,50 +44,43 @@ function AlbumDetailContent() {
   const [albumDetail, setAlbumDetail] = useState<AlbumDetail | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
-
-  // 토큰 상태 확인
-  const accessToken = getCookieValue('accessToken');
+  const [isDeleting, setIsDeleting] = useState(false);
 
   useEffect(() => {
-    if (!groupId || !albumId || !accessToken) {
+    if (!groupId || !albumId) {
       setError('필요한 정보가 없습니다.');
+      setLoading(false);
+      return;
+    }
+
+    // 토큰 상태 확인
+    const accessToken = getCookieValue('accessToken');
+    if (!accessToken) {
+      setError('로그인이 필요합니다.');
       setLoading(false);
       return;
     }
 
     const fetchAlbumDetail = async () => {
       try {
-        // 앨범 상세 정보 조회
-        const response = await fetch(`/api/groups/${groupId}/albums`, {
-          method: 'GET',
-          headers: {
-            Authorization: `Bearer ${accessToken}`,
-          },
-        });
+        // 앨범 상세 정보 조회 - 새로운 API 엔드포인트 사용
+        const response = await fetch(
+          `/api/groups/${groupId}/albums/${albumId}`,
+          {
+            method: 'GET',
+            headers: {
+              Authorization: `Bearer ${accessToken}`,
+            },
+          }
+        );
 
         if (response.ok) {
-          const albums = await response.json();
-          console.log('[앨범 상세] API 응답:', albums);
-          console.log('[앨범 상세] 찾는 albumId:', albumId);
-
-          const album = albums.find(
-            (a: AlbumDetail) => String(a.memoryId) === String(albumId)
-          );
-
-          if (album) {
-            console.log('[앨범 상세] 찾은 앨범:', album);
-            setAlbumDetail(album);
-          } else {
-            console.log(
-              '[앨범 상세] 앨범을 찾을 수 없음. 사용 가능한 앨범들:',
-              albums.map((a: AlbumDetail) => ({
-                memoryId: a.memoryId,
-                description: a.description,
-              }))
-            );
-            setError('앨범을 찾을 수 없습니다.');
-          }
+          const album = await response.json();
+          console.log('[앨범 상세] API 응답:', album);
+          setAlbumDetail(album);
         } else {
+          const errorText = await response.text();
+          console.error('[앨범 상세] API 오류:', response.status, errorText);
           setError('앨범 정보를 불러오는데 실패했습니다.');
         }
       } catch (err) {
@@ -96,7 +92,7 @@ function AlbumDetailContent() {
     };
 
     fetchAlbumDetail();
-  }, [groupId, albumId, accessToken]);
+  }, [groupId, albumId]);
 
   // 날짜 포맷팅
   const formatDate = (dateString: string) => {
@@ -111,13 +107,57 @@ function AlbumDetailContent() {
   // 이미지 URL 배열 생성
   const getImageUrls = (album: AlbumDetail) => {
     const urls = [];
-    // 기본 imageUrl 필드 확인
+    // API 스펙에 따른 이미지 필드들 확인
+    if (album.imageUrl1) urls.push(album.imageUrl1);
+    if (album.imageUrl2) urls.push(album.imageUrl2);
+    if (album.imageUrl3) urls.push(album.imageUrl3);
+    // 호환성을 위한 추가 필드들
     if (album.imageUrl) urls.push(album.imageUrl);
-    // 추가 이미지 필드들 확인
     if (album.albumImage) urls.push(album.albumImage);
-    if (album.albumImage2) urls.push(album.albumImage2);
-    if (album.albumImage3) urls.push(album.albumImage3);
     return urls;
+  };
+
+  // 앨범 삭제 함수
+  const handleDeleteAlbum = async () => {
+    if (!confirm('정말로 이 앨범을 삭제하시겠습니까?')) {
+      return;
+    }
+
+    setIsDeleting(true);
+
+    try {
+      const accessToken = getCookieValue('accessToken');
+      if (!accessToken) {
+        alert('로그인이 필요합니다.');
+        return;
+      }
+
+      const response = await fetch(`/api/groups/${groupId}/albums/${albumId}`, {
+        method: 'DELETE',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
+
+      if (response.ok) {
+        alert('앨범이 삭제되었습니다.');
+        router.back(); // 이전 페이지로 돌아가기
+      } else {
+        const errorText = await response.text();
+        console.error('[앨범 삭제] API 오류:', response.status, errorText);
+
+        if (response.status === 403) {
+          alert('작성자만 삭제할 수 있습니다.');
+        } else {
+          alert('앨범 삭제에 실패했습니다.');
+        }
+      }
+    } catch (err) {
+      console.error('[앨범 삭제 오류]', err);
+      alert('앨범 삭제 중 오류가 발생했습니다.');
+    } finally {
+      setIsDeleting(false);
+    }
   };
 
   // 로딩 상태
@@ -230,20 +270,64 @@ function AlbumDetailContent() {
           </svg>
         </button>
         <h2 className="text-2xl font-semibold text-center flex-1">앨범 상세</h2>
+        <button
+          onClick={handleDeleteAlbum}
+          disabled={isDeleting}
+          className="text-xs text-white border border-red-200 px-3 py-1.5 rounded-lg font-medium shadow-sm hover:shadow-md hover:border-red-300 transition-all duration-300 hover:scale-105 active:scale-95 backdrop-blur-sm disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100"
+          style={
+            {
+              backgroundColor: '#f5b2b2',
+              '--hover-bg-color': '#e89999',
+            } as React.CSSProperties
+          }
+          onMouseEnter={(e) => {
+            if (!isDeleting) {
+              e.currentTarget.style.backgroundColor = '#e89999';
+            }
+          }}
+          onMouseLeave={(e) => {
+            if (!isDeleting) {
+              e.currentTarget.style.backgroundColor = '#f5b2b2';
+            }
+          }}
+        >
+          {isDeleting ? (
+            <div className="flex items-center gap-2">
+              <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white"></div>
+              <span>삭제 중...</span>
+            </div>
+          ) : (
+            <div className="flex items-center gap-2">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={2}
+                stroke="white"
+                className="w-4 h-4"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
+                />
+              </svg>
+              <span>삭제</span>
+            </div>
+          )}
+        </button>
       </div>
 
       <div className="space-y-4 flex-1 overflow-y-auto scroll-overlay pb-20">
         {/* 제목 */}
         <div className="mb-4 p-4 bg-white rounded-lg shadow-sm">
           <label className="block mb-2 font-medium text-gray-700">제목</label>
-          <div className="text-lg font-semibold text-gray-900">
+          <h3 className="text-lg font-semibold text-gray-900">
             {albumDetail.title ||
               albumDetail.albumTitle ||
               albumDetail.memoryTitle ||
-              albumDetail.albumName ||
-              albumDetail.name ||
               `앨범 #${albumDetail.memoryId}`}
-          </div>
+          </h3>
         </div>
 
         {/* 설명 */}
@@ -350,13 +434,8 @@ function AlbumDetailContent() {
 
         {/* 생성일 */}
         {albumDetail.createdAt && (
-          <div className="mb-4 p-4 bg-white rounded-lg shadow-sm">
-            <label className="block mb-2 font-medium text-gray-700">
-              생성일
-            </label>
-            <div className="text-gray-600 text-sm">
-              {formatDate(albumDetail.createdAt)}
-            </div>
+          <div className="text-gray-600 text-sm" style={{ textAlign: 'right' }}>
+            생성일: {formatDate(albumDetail.createdAt)}
           </div>
         )}
       </div>

--- a/src/app/front/my-home/group/album/detail/page.tsx
+++ b/src/app/front/my-home/group/album/detail/page.tsx
@@ -35,6 +35,16 @@ type AlbumDetail = {
   memoryLocation?: string;
 };
 
+interface EditFormData {
+  title: string;
+  content: string;
+  imageUrl1: string;
+  imageUrl2: string;
+  imageUrl3: string;
+  location: string;
+  memoryDate: string;
+}
+
 function AlbumDetailContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -45,6 +55,19 @@ function AlbumDetailContent() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [isDeleting, setIsDeleting] = useState(false);
+  const [isEditing, setIsEditing] = useState(false);
+  const [showEditModal, setShowEditModal] = useState(false);
+  const [editFormData, setEditFormData] = useState<EditFormData>({
+    title: '',
+    content: '',
+    imageUrl1: '',
+    imageUrl2: '',
+    imageUrl3: '',
+    location: '',
+    memoryDate: '',
+  });
+  const [imagePreviews, setImagePreviews] = useState<string[]>([]);
+  const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
 
   useEffect(() => {
     if (!groupId || !albumId) {
@@ -94,8 +117,8 @@ function AlbumDetailContent() {
     fetchAlbumDetail();
   }, [groupId, albumId]);
 
-  // 날짜 포맷팅
-  const formatDate = (dateString: string) => {
+  // 날짜 포맷팅 (표시용)
+  const formatDisplayDate = (dateString: string) => {
     const date = new Date(dateString);
     return date.toLocaleDateString('ko-KR', {
       year: 'numeric',
@@ -157,6 +180,176 @@ function AlbumDetailContent() {
       alert('앨범 삭제 중 오류가 발생했습니다.');
     } finally {
       setIsDeleting(false);
+    }
+  };
+
+  // 앨범 수정 함수
+  const handleEditAlbum = () => {
+    if (albumDetail) {
+      setEditFormData({
+        title: albumDetail.title || '',
+        content: albumDetail.content || '',
+        imageUrl1: albumDetail.imageUrl1 || '',
+        imageUrl2: albumDetail.imageUrl2 || '',
+        imageUrl3: albumDetail.imageUrl3 || '',
+        location: albumDetail.location || '',
+        memoryDate: albumDetail.memoryDate || '',
+      });
+
+      // 기존 이미지들을 미리보기에 추가
+      const existingImages = [
+        albumDetail.imageUrl1,
+        albumDetail.imageUrl2,
+        albumDetail.imageUrl3,
+      ].filter(Boolean) as string[];
+      setImagePreviews(existingImages);
+      setSelectedFiles([]);
+
+      setShowEditModal(true);
+    }
+  };
+
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files || []);
+    if (files.length > 0) {
+      const newFiles = [...selectedFiles, ...files];
+      setSelectedFiles(newFiles);
+
+      // 새로 추가한 파일 미리보기 생성
+      files.forEach((file) => {
+        const reader = new FileReader();
+        reader.onload = () => {
+          setImagePreviews((prev) => [...prev, reader.result as string]);
+        };
+        reader.readAsDataURL(file);
+      });
+    }
+  };
+
+  const removeImage = (index: number) => {
+    setImagePreviews((prev) => prev.filter((_, i) => i !== index));
+    setSelectedFiles((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const handleUpdateAlbum = async () => {
+    setIsEditing(true);
+
+    try {
+      const accessToken = getCookieValue('accessToken');
+      if (!accessToken) {
+        alert('로그인이 필요합니다.');
+        return;
+      }
+
+      // 새로 선택된 이미지들 업로드
+      const uploadedImageUrls: string[] = [];
+
+      if (selectedFiles.length > 0) {
+        for (const file of selectedFiles) {
+          const ext = file.name.split('.').pop()?.toLowerCase() || 'jpg';
+
+          const presignRes = await fetch(
+            `/api/albums/${groupId}/upload-url?extension=${ext}`,
+            {
+              method: 'GET',
+              headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${accessToken}`,
+              },
+            }
+          );
+
+          if (presignRes.ok) {
+            const responseData = await presignRes.json();
+
+            const uploadUrl =
+              responseData.uploadUrl ||
+              responseData.presignedUrl ||
+              responseData.url ||
+              responseData.additionalProp1 ||
+              Object.values(responseData)[0];
+            const fileUrl =
+              responseData.fileUrl ||
+              responseData.publicUrl ||
+              responseData.downloadUrl ||
+              responseData.additionalProp2 ||
+              Object.values(responseData)[1];
+
+            if (uploadUrl) {
+              const uploadResponse = await fetch(uploadUrl, {
+                method: 'PUT',
+                headers: {
+                  'Content-Type': file.type,
+                },
+                body: file,
+              });
+
+              if (uploadResponse.ok) {
+                const finalUrl = fileUrl || uploadUrl.split('?')[0];
+                uploadedImageUrls.push(finalUrl);
+              } else {
+                console.error(
+                  '[이미지 업로드 실패]',
+                  file.name,
+                  uploadResponse.status
+                );
+              }
+            }
+          }
+        }
+      }
+
+      // 기존 이미지들과 새로 업로드된 이미지들을 합침
+      const existingImages = [
+        editFormData.imageUrl1,
+        editFormData.imageUrl2,
+        editFormData.imageUrl3,
+      ].filter(Boolean);
+
+      const allImages = [...existingImages, ...uploadedImageUrls];
+
+      // 업데이트할 데이터 준비
+      const updateData = {
+        title: editFormData.title,
+        content: editFormData.content,
+        location: editFormData.location,
+        memoryDate: editFormData.memoryDate,
+        imageUrl1: allImages[0] || null,
+        imageUrl2: allImages[1] || null,
+        imageUrl3: allImages[2] || null,
+      };
+
+      const response = await fetch(`/api/groups/${groupId}/albums/${albumId}`, {
+        method: 'PATCH',
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(updateData),
+      });
+
+      if (response.ok) {
+        const updatedAlbum = await response.json();
+        setAlbumDetail(updatedAlbum);
+        setShowEditModal(false);
+        setImagePreviews([]);
+        setSelectedFiles([]);
+        alert('앨범이 수정되었습니다.');
+      } else {
+        const errorText = await response.text();
+        console.error('[앨범 수정] API 오류:', response.status, errorText);
+
+        if (response.status === 403) {
+          alert('작성자만 수정할 수 있습니다.');
+        } else {
+          alert('앨범 수정에 실패했습니다.');
+        }
+      }
+    } catch (err) {
+      console.error('[앨범 수정 오류]', err);
+      alert('앨범 수정 중 오류가 발생했습니다.');
+    } finally {
+      setIsEditing(false);
     }
   };
 
@@ -270,33 +463,23 @@ function AlbumDetailContent() {
           </svg>
         </button>
         <h2 className="text-2xl font-semibold text-center flex-1">앨범 상세</h2>
-        <button
-          onClick={handleDeleteAlbum}
-          disabled={isDeleting}
-          className="text-xs text-white border border-red-200 px-3 py-1.5 rounded-lg font-medium shadow-sm hover:shadow-md hover:border-red-300 transition-all duration-300 hover:scale-105 active:scale-95 backdrop-blur-sm disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100"
-          style={
-            {
-              backgroundColor: '#f5b2b2',
-              '--hover-bg-color': '#e89999',
-            } as React.CSSProperties
-          }
-          onMouseEnter={(e) => {
-            if (!isDeleting) {
-              e.currentTarget.style.backgroundColor = '#e89999';
+        <div className="flex gap-2">
+          <button
+            onClick={handleEditAlbum}
+            className="text-xs text-white border border-purple-200 px-3 py-1.5 rounded-lg font-medium shadow-sm hover:shadow-md hover:border-purple-300 transition-all duration-300 hover:scale-105 active:scale-95 backdrop-blur-sm"
+            style={
+              {
+                backgroundColor: '#aa96fc',
+                '--hover-bg-color': '#8b5cf6',
+              } as React.CSSProperties
             }
-          }}
-          onMouseLeave={(e) => {
-            if (!isDeleting) {
-              e.currentTarget.style.backgroundColor = '#f5b2b2';
-            }
-          }}
-        >
-          {isDeleting ? (
-            <div className="flex items-center gap-2">
-              <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white"></div>
-              <span>삭제 중...</span>
-            </div>
-          ) : (
+            onMouseEnter={(e) => {
+              e.currentTarget.style.backgroundColor = '#8b5cf6';
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.backgroundColor = '#aa96fc';
+            }}
+          >
             <div className="flex items-center gap-2">
               <svg
                 xmlns="http://www.w3.org/2000/svg"
@@ -309,13 +492,59 @@ function AlbumDetailContent() {
                 <path
                   strokeLinecap="round"
                   strokeLinejoin="round"
-                  d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
+                  d="M16.862 4.487l1.687-1.688a1.875 1.875 0 112.652 2.652L10.582 16.07a4.5 4.5 0 01-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 011.13-1.897l8.932-8.931zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0115.75 21H5.25A2.25 2.25 0 013 18.75V8.25A2.25 2.25 0 015.25 6H10"
                 />
               </svg>
-              <span>삭제</span>
+              <span>수정</span>
             </div>
-          )}
-        </button>
+          </button>
+          <button
+            onClick={handleDeleteAlbum}
+            disabled={isDeleting}
+            className="text-xs text-white border border-red-200 px-3 py-1.5 rounded-lg font-medium shadow-sm hover:shadow-md hover:border-red-300 transition-all duration-300 hover:scale-105 active:scale-95 backdrop-blur-sm disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:scale-100"
+            style={
+              {
+                backgroundColor: '#f5b2b2',
+                '--hover-bg-color': '#e89999',
+              } as React.CSSProperties
+            }
+            onMouseEnter={(e) => {
+              if (!isDeleting) {
+                e.currentTarget.style.backgroundColor = '#e89999';
+              }
+            }}
+            onMouseLeave={(e) => {
+              if (!isDeleting) {
+                e.currentTarget.style.backgroundColor = '#f5b2b2';
+              }
+            }}
+          >
+            {isDeleting ? (
+              <div className="flex items-center gap-2">
+                <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-white"></div>
+                <span>삭제 중...</span>
+              </div>
+            ) : (
+              <div className="flex items-center gap-2">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth={2}
+                  stroke="white"
+                  className="w-4 h-4"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
+                  />
+                </svg>
+                <span>삭제</span>
+              </div>
+            )}
+          </button>
+        </div>
       </div>
 
       <div className="space-y-4 flex-1 overflow-y-auto scroll-overlay pb-20">
@@ -427,7 +656,7 @@ function AlbumDetailContent() {
                   d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
                 />
               </svg>
-              {formatDate(albumDetail.memoryDate)}
+              {formatDisplayDate(albumDetail.memoryDate)}
             </div>
           </div>
         )}
@@ -435,10 +664,242 @@ function AlbumDetailContent() {
         {/* 생성일 */}
         {albumDetail.createdAt && (
           <div className="text-gray-600 text-sm" style={{ textAlign: 'right' }}>
-            생성일: {formatDate(albumDetail.createdAt)}
+            생성일: {formatDisplayDate(albumDetail.createdAt)}
           </div>
         )}
       </div>
+
+      {/* 수정 모달 */}
+      {showEditModal && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-[9999] p-4">
+          <div className="bg-white rounded-lg shadow-xl max-w-md w-full max-h-[80vh] flex flex-col">
+            <div className="p-6 flex-shrink-0">
+              <div className="flex items-center justify-between mb-6">
+                <h3 className="text-lg font-semibold text-gray-900">
+                  앨범 수정
+                </h3>
+                <button
+                  onClick={() => setShowEditModal(false)}
+                  className="text-gray-400 hover:text-gray-600"
+                >
+                  <svg
+                    className="w-6 h-6"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M6 18L18 6M6 6l12 12"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </div>
+
+            <div className="px-6 flex-1 overflow-y-auto">
+              <div className="space-y-4">
+                {/* 제목 */}
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                    제목 *
+                  </label>
+                  <input
+                    type="text"
+                    value={editFormData.title}
+                    onChange={(e) =>
+                      setEditFormData({
+                        ...editFormData,
+                        title: e.target.value,
+                      })
+                    }
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                    placeholder="제목을 입력하세요"
+                  />
+                </div>
+
+                {/* 내용 */}
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                    내용
+                  </label>
+                  <textarea
+                    value={editFormData.content}
+                    onChange={(e) =>
+                      setEditFormData({
+                        ...editFormData,
+                        content: e.target.value,
+                      })
+                    }
+                    rows={4}
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                    placeholder="내용을 입력하세요"
+                  />
+                </div>
+
+                {/* 위치 */}
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                    위치
+                  </label>
+                  <input
+                    type="text"
+                    value={editFormData.location}
+                    onChange={(e) =>
+                      setEditFormData({
+                        ...editFormData,
+                        location: e.target.value,
+                      })
+                    }
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                    placeholder="위치를 입력하세요"
+                  />
+                </div>
+
+                {/* 추억 날짜 */}
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                    추억 날짜
+                  </label>
+                  <input
+                    type="date"
+                    value={editFormData.memoryDate}
+                    onChange={(e) =>
+                      setEditFormData({
+                        ...editFormData,
+                        memoryDate: e.target.value,
+                      })
+                    }
+                    className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  />
+                </div>
+
+                {/* 이미지 첨부 */}
+                <div>
+                  <label className="block text-sm font-medium text-gray-700 mb-2">
+                    이미지 첨부 ({imagePreviews.length}장)
+                  </label>
+                  <div className="flex flex-col items-center gap-4">
+                    {/* 이미지 미리보기 슬라이더 */}
+                    {imagePreviews.length > 0 ? (
+                      <div className="w-full">
+                        <div className="overflow-x-auto">
+                          <div
+                            className="flex gap-2 py-2"
+                            style={{ width: `${imagePreviews.length * 120}px` }}
+                          >
+                            {imagePreviews.map((preview, index) => (
+                              <div
+                                key={index}
+                                className="relative flex-shrink-0 w-28 h-28"
+                              >
+                                <Image
+                                  src={preview}
+                                  alt={`미리보기 ${index + 1}`}
+                                  width={112}
+                                  height={112}
+                                  className="w-full h-full rounded-lg object-cover border border-gray-200"
+                                />
+                                <button
+                                  type="button"
+                                  onClick={() => removeImage(index)}
+                                  className="absolute -top-1 -right-1 bg-red-500 text-white rounded-full w-5 h-5 flex items-center justify-center text-xs hover:bg-red-600 transition-colors"
+                                >
+                                  ×
+                                </button>
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                      </div>
+                    ) : (
+                      <div className="w-full h-32 border-2 border-dashed border-gray-300 rounded-lg flex items-center justify-center bg-gray-50">
+                        <div className="text-center">
+                          <svg
+                            className="w-12 h-12 text-gray-400 mx-auto mb-2"
+                            fill="none"
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={2}
+                              d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+                            />
+                          </svg>
+                          <p className="text-gray-500 text-sm">
+                            이미지를 선택해주세요
+                          </p>
+                          <p className="text-gray-400 text-xs mt-1">
+                            여러 장 선택 가능
+                          </p>
+                        </div>
+                      </div>
+                    )}
+
+                    {/* 파일 선택 버튼 */}
+                    <div className="w-full">
+                      <input
+                        type="file"
+                        accept="image/*"
+                        multiple
+                        onChange={handleImageChange}
+                        className="hidden"
+                        id="edit-image-upload"
+                      />
+                      <label
+                        htmlFor="edit-image-upload"
+                        className="w-full bg-[#9477ff] hover:bg-[#6845f5] text-white py-2 px-4 rounded-lg cursor-pointer transition-colors text-center block"
+                      >
+                        {imagePreviews.length > 0
+                          ? '이미지 추가'
+                          : '이미지 선택'}
+                      </label>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div className="p-6 flex-shrink-0 border-t border-gray-200">
+              <div className="flex gap-3">
+                <button
+                  onClick={() => setShowEditModal(false)}
+                  className="flex-1 px-4 py-2 text-gray-700 bg-gray-100 border border-gray-300 rounded-md hover:bg-gray-200 transition-colors"
+                >
+                  취소
+                </button>
+                <button
+                  onClick={handleUpdateAlbum}
+                  disabled={isEditing}
+                  className="flex-1 px-4 py-2 text-white border border-purple-600 rounded-md disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+                  style={
+                    {
+                      backgroundColor: '#6845f5',
+                      '--hover-bg-color': '#5b35e0',
+                    } as React.CSSProperties
+                  }
+                  onMouseEnter={(e) => {
+                    if (!isEditing) {
+                      e.currentTarget.style.backgroundColor = '#5b35e0';
+                    }
+                  }}
+                  onMouseLeave={(e) => {
+                    if (!isEditing) {
+                      e.currentTarget.style.backgroundColor = '#6845f5';
+                    }
+                  }}
+                >
+                  {isEditing ? '수정 중...' : '수정'}
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/front/my-home/group/detail/page.tsx
+++ b/src/app/front/my-home/group/detail/page.tsx
@@ -141,7 +141,7 @@ function GroupDetailContent() {
       });
       const text = await res.text();
       const data = JSON.parse(text);
-      setSchedules(data); // ✅ 일정 다시 설정
+      setSchedules(data);
     } catch (err) {
       console.error('일정 다시 불러오기 실패', err);
     }
@@ -172,122 +172,123 @@ function GroupDetailContent() {
         <h2 className="text-2xl font-semibold text-center flex-1">그룹 상세</h2>
       </div>
 
-      {/* 그룹 이름 */}
-      <div className="bg-white p-4 rounded-md shadow mb-4 flex items-center justify-between">
-        <h1 className="text-xl font-bold">{groupName}</h1>
-        <Link
-          href={`/front/my-home/member/list?groupId=${groupId}`}
-          className="text-sm px-2 py-1 rounded text-white bg-[#9477ff] hover:bg-[#6845f5]"
-        >
-          멤버 보기
-        </Link>
-      </div>
-
-      {/* 그룹 추억 앨범 */}
-      <div className="bg-white p-4 rounded-md shadow mb-4">
-        <div className="flex justify-between items-center mb-2">
-          <h2 className="font-semibold">그룹 추억 앨범</h2>
-          <button
-            onClick={() =>
-              router.push(
-                `/front/my-home/group/album/albumList?groupId=${groupId}`
-              )
-            }
-            className="text-sm px-2 py-1 rounded text-white bg-[#9477ff] hover:bg-[#6845f5]"
-          >
-            추억 앨범 보기
-          </button>
-        </div>
-
-        <div className="bg-gray-100 overflow-hidden p-3">
-          {loading ? (
-            <div className="text-sm text-gray-400">불러오는 중...</div>
-          ) : error ? (
-            <div className="flex justify-center items-center h-full text-center text-sm text-red-500">
-              {error}
-            </div>
-          ) : albums.length === 0 ? (
-            <div className="text-sm text-gray-500">앨범이 없습니다.</div>
-          ) : (
-            <div className="overflow-x-auto h-full">
-              <div
-                className="flex gap-3 py-1"
-                style={{ width: `${albums.length * 120}px` }}
-              >
-                {albums.map((album) => (
-                  <div
-                    key={album.memoryId}
-                    className="relative flex-shrink-0 w-28 h-28 bg-gray-100 rounded overflow-hidden shadow"
-                  >
-                    {album.imageUrl ? (
-                      <Image
-                        src={album.imageUrl}
-                        alt={album.description}
-                        fill
-                        className="object-cover"
-                      />
-                    ) : (
-                      <div className="flex items-center justify-center h-full text-xs text-gray-500 p-1 text-center">
-                        {album.description}
-                      </div>
-                    )}
-                  </div>
-                ))}
-              </div>
-            </div>
-          )}
-        </div>
-      </div>
-
-      {/* 그룹 일정 */}
-      <div className="bg-white p-4 rounded-md shadow">
-        <div className="flex justify-between items-center mb-2">
-          <h2 className="font-semibold">그룹 일정</h2>
+      <div className="space-y-4 flex-1 overflow-y-auto scroll-overlay pb-20">
+        {/* 그룹 이름 */}
+        <div className="bg-white p-4 rounded-md shadow mb-4 flex items-center justify-between">
+          <h1 className="text-xl font-bold">{groupName}</h1>
           <Link
-            href={`/front/my-home/group/schedule?groupId=${groupId}`}
+            href={`/front/my-home/member/list?groupId=${groupId}`}
             className="text-sm px-2 py-1 rounded text-white bg-[#9477ff] hover:bg-[#6845f5]"
           >
-            일정 추가
+            멤버 보기
           </Link>
         </div>
 
-        {/* 달력 */}
-        <div className="bg-gray-100 rounded p-4">
-          <Calendar
-            value={value}
-            onChange={handleDateChange}
-            calendarType="iso8601"
-            locale="ko-KR"
-            formatDay={() => ''}
-            onClickDay={(date: Date) => {
-              const dateStr = getLocalDateString(date);
-              const matched = schedules.find((s) =>
-                s.scheduleDate.startsWith(dateStr)
-              );
-              if (matched) {
-                setSelectedScheduleId(matched.scheduleId);
+        {/* 그룹 추억 앨범 */}
+        <div className="bg-white p-4 rounded-md shadow mb-4">
+          <div className="flex justify-between items-center mb-2">
+            <h2 className="font-semibold">그룹 추억 앨범</h2>
+            <button
+              onClick={() =>
+                router.push(
+                  `/front/my-home/group/album/albumList?groupId=${groupId}`
+                )
               }
-            }}
-            tileClassName={({ date, view }) => {
-              if (view !== 'month') return '';
+              className="text-sm px-2 py-1 rounded text-white bg-[#9477ff] hover:bg-[#6845f5]"
+            >
+              추억 앨범 보기
+            </button>
+          </div>
 
-              const day = date.getDay();
-              if (day === 6) return 'weekday-saturday'; // 토요일
-              return '';
-            }}
-            tileContent={({ date, view }) =>
-              view === 'month' ? (
-                <div className="relative flex items-center justify-center mx-auto w-[30px] h-[30px]">
-                  {/* 일정 있는 날짜: 빨간 배경 */}
-                  {schedules.some((s) =>
-                    s.scheduleDate.startsWith(getLocalDateString(date))
-                  ) && (
-                    <div className="absolute inset-0 rounded-full bg-[#ff9d9d] z-0" />
-                  )}
+          <div className="bg-gray-100 overflow-hidden p-3">
+            {loading ? (
+              <div className="text-sm text-gray-400">불러오는 중...</div>
+            ) : error ? (
+              <div className="flex justify-center items-center h-full text-center text-sm text-red-500">
+                {error}
+              </div>
+            ) : albums.length === 0 ? (
+              <div className="text-sm text-gray-500">앨범이 없습니다.</div>
+            ) : (
+              <div className="overflow-x-auto h-full">
+                <div
+                  className="flex gap-3 py-1"
+                  style={{ width: `${albums.length * 120}px` }}
+                >
+                  {albums.map((album) => (
+                    <div
+                      key={album.memoryId}
+                      className="relative flex-shrink-0 w-28 h-28 bg-gray-100 rounded overflow-hidden shadow"
+                    >
+                      {album.imageUrl ? (
+                        <Image
+                          src={album.imageUrl}
+                          alt={album.description}
+                          fill
+                          className="object-cover"
+                        />
+                      ) : (
+                        <div className="flex items-center justify-center h-full text-xs text-gray-500 p-1 text-center">
+                          {album.description}
+                        </div>
+                      )}
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
 
-                  {/* 날짜 텍스트 */}
-                  <div
-                    className={`
+        {/* 그룹 일정 */}
+        <div className="bg-white p-4 rounded-md shadow">
+          <div className="flex justify-between items-center mb-2">
+            <h2 className="font-semibold">그룹 일정</h2>
+            <Link
+              href={`/front/my-home/group/schedule?groupId=${groupId}`}
+              className="text-sm px-2 py-1 rounded text-white bg-[#9477ff] hover:bg-[#6845f5]"
+            >
+              일정 추가
+            </Link>
+          </div>
+
+          {/* 달력 */}
+          <div className="bg-gray-100 rounded p-4">
+            <Calendar
+              value={value}
+              onChange={handleDateChange}
+              calendarType="iso8601"
+              locale="ko-KR"
+              formatDay={() => ''}
+              onClickDay={(date: Date) => {
+                const dateStr = getLocalDateString(date);
+                const matched = schedules.find((s) =>
+                  s.scheduleDate.startsWith(dateStr)
+                );
+                if (matched) {
+                  setSelectedScheduleId(matched.scheduleId);
+                }
+              }}
+              tileClassName={({ date, view }) => {
+                if (view !== 'month') return '';
+
+                const day = date.getDay();
+                if (day === 6) return 'weekday-saturday'; // 토요일
+                return '';
+              }}
+              tileContent={({ date, view }) =>
+                view === 'month' ? (
+                  <div className="relative flex items-center justify-center mx-auto w-[30px] h-[30px]">
+                    {/* 일정 있는 날짜: 빨간 배경 */}
+                    {schedules.some((s) =>
+                      s.scheduleDate.startsWith(getLocalDateString(date))
+                    ) && (
+                      <div className="absolute inset-0 rounded-full bg-[#ff9d9d] z-0" />
+                    )}
+
+                    {/* 날짜 텍스트 */}
+                    <div
+                      className={`
             rounded-full w-full h-full flex items-center justify-center z-10
             ${
               (Array.isArray(value)
@@ -304,27 +305,28 @@ function GroupDetailContent() {
                 : ''
             }
           `}
-                  >
-                    {date.getDate()}
+                    >
+                      {date.getDate()}
+                    </div>
                   </div>
-                </div>
-              ) : null
-            }
-          />
-        </div>
+                ) : null
+              }
+            />
+          </div>
 
-        {/* 팝업 */}
-        {selectedScheduleId && groupId && (
-          <ScheduleModal
-            scheduleId={selectedScheduleId}
-            groupId={groupId}
-            onClose={() => setSelectedScheduleId(null)}
-            onDeleteSuccess={() => {
-              setSelectedScheduleId(null);
-              fetchSchedules();
-            }}
-          />
-        )}
+          {/* 팝업 */}
+          {selectedScheduleId && groupId && (
+            <ScheduleModal
+              scheduleId={selectedScheduleId}
+              groupId={groupId}
+              onClose={() => setSelectedScheduleId(null)}
+              onDeleteSuccess={() => {
+                setSelectedScheduleId(null);
+                fetchSchedules();
+              }}
+            />
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/app/front/my-home/group/detail/page.tsx
+++ b/src/app/front/my-home/group/detail/page.tsx
@@ -12,6 +12,9 @@ type Album = {
   description: string;
   imageUrl: string;
   createdAt: string;
+  title?: string;
+  content?: string;
+  location?: string;
 };
 
 type ScheduleItem = {
@@ -94,6 +97,8 @@ function GroupDetailContent() {
           if (!res.ok) throw new Error(data.message || '앨범 조회 실패');
           if (!Array.isArray(data))
             throw new Error('응답 데이터가 배열이 아닙니다.');
+          console.log('[그룹 상세 - 앨범] API 응답 데이터:', data);
+          console.log('[그룹 상세 - 앨범] 첫 번째 앨범 구조:', data[0]);
           setAlbums(data);
         } catch (err) {
           console.error('[앨범 조회 오류]', err);

--- a/src/app/front/search/SearchUser.tsx
+++ b/src/app/front/search/SearchUser.tsx
@@ -23,7 +23,9 @@ export default function SearchUser() {
   const [users, setUsers] = useState<User[]>([]);
   const [isSearching, setIsSearching] = useState(false);
   const [errorMsg, setErrorMsg] = useState('');
-  const [requestingFriends, setRequestingFriends] = useState<Set<number>>(new Set());
+  const [requestingFriends, setRequestingFriends] = useState<Set<number>>(
+    new Set()
+  );
 
   const getToken = () => getCookieValue('accessToken');
 
@@ -58,10 +60,42 @@ export default function SearchUser() {
         const data = await res.json();
 
         if (res.ok) {
+          console.log('[검색 결과] 백엔드 응답:', data);
           const sorted = (data.users ?? []).sort((a: User, b: User) =>
             a.nickname.localeCompare(b.nickname)
           );
-          setUsers(sorted);
+          console.log('[검색 결과] 정렬된 사용자 목록:', sorted);
+
+          // 친구 목록을 가져와서 isFriend 상태를 업데이트
+          try {
+            const friendsResponse = await fetch('/api/friends', {
+              headers: {
+                Authorization: `Bearer ${token}`,
+              },
+            });
+
+            if (friendsResponse.ok) {
+              const friendsData = await friendsResponse.json();
+              console.log('[친구 목록] 현재 친구들:', friendsData);
+
+              // 검색된 사용자들의 isFriend 상태를 업데이트
+              const updatedUsers = sorted.map((user: User) => ({
+                ...user,
+                isFriend: friendsData.some(
+                  (friend: { friendUserId: number }) =>
+                    friend.friendUserId === user.id
+                ),
+              }));
+
+              console.log('[검색 결과] 친구 상태 업데이트 후:', updatedUsers);
+              setUsers(updatedUsers);
+            } else {
+              setUsers(sorted);
+            }
+          } catch (friendsError) {
+            console.error('[친구 목록 조회 실패]', friendsError);
+            setUsers(sorted);
+          }
 
           if (sorted.length === 0) {
             setErrorMsg('찾으시는 친구가 없어요');
@@ -82,7 +116,7 @@ export default function SearchUser() {
 
   const handleFriendRequest = async (friendId: number) => {
     const token = getToken();
-    
+
     if (!token) {
       alert('로그인이 필요합니다.');
       router.replace('/front/account/login');
@@ -96,16 +130,16 @@ export default function SearchUser() {
 
     try {
       // 요청 중 상태로 설정
-      setRequestingFriends(prev => new Set(prev).add(friendId));
+      setRequestingFriends((prev) => new Set(prev).add(friendId));
 
       const response = await fetch('/api/friends/request', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`,
+          Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify({
-          friendId: friendId
+          friendId: friendId,
         }),
       });
 
@@ -113,10 +147,21 @@ export default function SearchUser() {
 
       if (response.ok) {
         alert('친구 신청이 완료되었습니다!');
-        // 성공 시 해당 유저의 상태를 업데이트할 수 있지만, 
-        // 현재 API 응답에 isFriend 상태 변경 정보가 없으므로 
-        // 단순히 성공 메시지만 표시
+        // 성공 시 해당 유저의 isFriend 상태를 true로 업데이트
+        setUsers((prevUsers) =>
+          prevUsers.map((user) =>
+            user.id === friendId ? { ...user, isFriend: true } : user
+          )
+        );
       } else {
+        // "이미 친구입니다" 에러인 경우 해당 유저의 isFriend 상태를 true로 업데이트
+        if (data.message === '이미 친구입니다.') {
+          setUsers((prevUsers) =>
+            prevUsers.map((user) =>
+              user.id === friendId ? { ...user, isFriend: true } : user
+            )
+          );
+        }
         alert(data.message || '친구 신청에 실패했습니다.');
       }
     } catch (error) {
@@ -124,7 +169,7 @@ export default function SearchUser() {
       alert('친구 신청 중 오류가 발생했습니다.');
     } finally {
       // 요청 완료 후 상태 제거
-      setRequestingFriends(prev => {
+      setRequestingFriends((prev) => {
         const newSet = new Set(prev);
         newSet.delete(friendId);
         return newSet;
@@ -170,7 +215,7 @@ export default function SearchUser() {
                   href={`/front/my-home?userId=${user.id}`}
                   className="px-4 py-3 rounded-lg transition-colors bg-main-color text-white small-ver bg-gray-300 text-sm"
                 >
-                  마이홈 놀러가기
+                  칭구칭구🫶
                 </Link>
               ) : (
                 <>
@@ -184,7 +229,9 @@ export default function SearchUser() {
                     onClick={() => handleFriendRequest(user.id)}
                     disabled={requestingFriends.has(user.id)}
                   >
-                    {requestingFriends.has(user.id) ? '신청 중...' : '친구 신청'}
+                    {requestingFriends.has(user.id)
+                      ? '신청 중...'
+                      : '친구 신청'}
                   </Button>
                 </>
               )}


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolves: https://github.com/DdNnTt/Chingu-Frontend/issues/110

## 📝작업 내용
- 추억 앨범 삭제 API 연동

## 스크린샷 (선택)

## 💬리뷰 요구사항(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 그룹 앨범 상세 페이지 추가: 조회, 이미지 갤러리, 수정/삭제, 이미지 업로드/미리보기 지원
  - 그룹 앨범 목록 개선: 새 섹션과 글쓰기 이동, 위치/콘텐츠 표시, 상세 페이지로 이동
  - 사용자 검색 결과에 실시간 친구 여부 반영 및 요청 후 상태 즉시 갱신
- Bug Fixes
  - 토큰 없을 때 인증 헤더 미전송으로 사용자 정보 조회 오류 사례 감소
- Style
  - 친구 리스트/요청 버튼 색상·호버·스케일 효과 개선
  - 그룹 상세 레이아웃 카드형 재구성, 앨범/일정 섹션 정돈
- Chores
  - 원격 이미지 허용 방식을 remotePatterns로 전환
<!-- end of auto-generated comment: release notes by coderabbit.ai -->