### PR TITLE
카카오, 구글 소셜 로그인 연동

### DIFF
--- a/src/app/front/account/login/page.tsx
+++ b/src/app/front/account/login/page.tsx
@@ -98,9 +98,6 @@ export default function Login() {
       // 쿠키로 저장 (secure, SameSite는 필요 시 조정)
       document.cookie = `accessToken=${accessToken}; path=/; secure; SameSite=Lax`;
 
-      // localStorage.setItem('tokenType', tokenType);
-      // localStorage.setItem('nickname', nickname);
-
       router.push('/front/my-home');
     } catch (error: unknown) {
       console.error('[로그인 실패]', error);
@@ -124,6 +121,21 @@ export default function Login() {
     } finally {
       setIsLoggingIn(false);
     }
+  };
+
+  // 소셜 로그인
+  const handleGoogleLogin = () => {
+    // 백엔드 제공 OAuth2 엔드포인트
+    console.log('Google OAuth2 로그인 시작');
+    window.location.href =
+      'https://chinguchingu.kro.kr/oauth2/authorization/google';
+  };
+
+  const handleKakaoLogin = () => {
+    // 백엔드 제공 OAuth2 엔드포인트
+    console.log('카카오 OAuth2 로그인 시작');
+    window.location.href =
+      'https://chinguchingu.kro.kr/oauth2/authorization/kakao';
   };
 
   // 로그인 후 진입
@@ -266,7 +278,10 @@ export default function Login() {
 
         {/* 소셜 로그인 */}
         <div className="social-login-wrap mt-12 animate-slideUp delay-1200 opacity-0">
-          <div className="border border-gray-300 text-sm px-4 py-3 rounded-xl w-full text-center bg-white hover:bg-gray-50 transition-all duration-200 cursor-pointer mb-3 flex items-center justify-center gap-2 shadow-sm hover:shadow-md">
+          <div
+            className="border border-gray-300 text-sm px-4 py-3 rounded-xl w-full text-center bg-white hover:bg-gray-50 transition-all duration-200 cursor-pointer mb-3 flex items-center justify-center gap-2 shadow-sm hover:shadow-md"
+            onClick={handleGoogleLogin}
+          >
             <svg className="w-5 h-5" viewBox="0 0 24 24">
               <path
                 fill="#4285F4"
@@ -287,7 +302,10 @@ export default function Login() {
             </svg>
             <span className="text-gray-700 font-medium">Google로 로그인</span>
           </div>
-          <div className="border border-gray-300 text-sm px-4 py-3 rounded-xl w-full text-center bg-white hover:bg-gray-50 transition-all duration-200 cursor-pointer flex items-center justify-center gap-2 shadow-sm hover:shadow-md">
+          <div
+            className="border border-gray-300 text-sm px-4 py-3 rounded-xl w-full text-center bg-white hover:bg-gray-50 transition-all duration-200 cursor-pointer flex items-center justify-center gap-2 shadow-sm hover:shadow-md"
+            onClick={handleKakaoLogin}
+          >
             <Image
               src="/images/kakao-logo.png"
               alt="카카오"

--- a/src/app/front/account/login/page.tsx
+++ b/src/app/front/account/login/page.tsx
@@ -125,17 +125,35 @@ export default function Login() {
 
   // 소셜 로그인
   const handleGoogleLogin = () => {
-    // 백엔드 제공 OAuth2 엔드포인트
-    console.log('Google OAuth2 로그인 시작');
-    window.location.href =
-      'https://chinguchingu.kro.kr/oauth2/authorization/google';
+    const base = process.env.NEXT_PUBLIC_API_BASE_URL;
+    if (!base) {
+      console.error('OAuth2 base URL 미설정: NEXT_PUBLIC_API_BASE_URL');
+      alert('OAuth2 설정 오류가 발생했습니다. 관리자에게 문의해주세요.');
+      return;
+    }
+
+    try {
+      window.location.assign(`${base}/oauth2/authorization/google`);
+    } catch (error) {
+      console.error('Google OAuth2 리다이렉트 오류:', error);
+      alert('Google 로그인 중 오류가 발생했습니다. 다시 시도해주세요.');
+    }
   };
 
   const handleKakaoLogin = () => {
-    // 백엔드 제공 OAuth2 엔드포인트
-    console.log('카카오 OAuth2 로그인 시작');
-    window.location.href =
-      'https://chinguchingu.kro.kr/oauth2/authorization/kakao';
+    const base = process.env.NEXT_PUBLIC_API_BASE_URL;
+    if (!base) {
+      console.error('OAuth2 base URL 미설정: NEXT_PUBLIC_API_BASE_URL');
+      alert('OAuth2 설정 오류가 발생했습니다. 관리자에게 문의해주세요.');
+      return;
+    }
+
+    try {
+      window.location.assign(`${base}/oauth2/authorization/kakao`);
+    } catch (error) {
+      console.error('카카오 OAuth2 리다이렉트 오류:', error);
+      alert('카카오 로그인 중 오류가 발생했습니다. 다시 시도해주세요.');
+    }
   };
 
   // 로그인 후 진입

--- a/src/app/front/account/oauth-proxy/page.tsx
+++ b/src/app/front/account/oauth-proxy/page.tsx
@@ -1,0 +1,158 @@
+'use client';
+
+import React, { useEffect, useState, Suspense } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+function OAuthProxyContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [status, setStatus] = useState<
+    'loading' | 'processing' | 'success' | 'error'
+  >('loading');
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    const handleOAuthProxy = async () => {
+      try {
+        setStatus('processing');
+        setMessage('OAuth2 콜백 처리 중...');
+
+        // URL에서 토큰 추출 시도
+        const token = searchParams.get('token');
+
+        if (token) {
+          console.log('OAuth2 토큰 수신 (프록시):', token);
+
+          // 토큰을 쿠키에 저장
+          document.cookie = `accessToken=${token}; path=/; secure; SameSite=Lax`;
+
+          setStatus('success');
+          setMessage('소셜 로그인 성공! 메인 페이지로 이동합니다.');
+
+          // 잠시 후 메인 페이지로 리다이렉트
+          setTimeout(() => {
+            router.push('/front/my-home');
+          }, 1500);
+        } else {
+          // 토큰이 없는 경우, 사용자에게 수동 입력 요청
+          setStatus('error');
+          setMessage('토큰을 찾을 수 없습니다. 수동으로 입력해주세요.');
+
+          // 수동 토큰 입력 UI 표시
+          setTimeout(() => {
+            const manualToken = prompt('OAuth2 토큰을 입력해주세요:');
+            if (manualToken) {
+              document.cookie = `accessToken=${manualToken}; path=/; secure; SameSite=Lax`;
+              router.push('/front/my-home');
+            } else {
+              router.push('/front/account/login');
+            }
+          }, 2000);
+        }
+      } catch (error) {
+        console.error('OAuth 프록시 처리 오류:', error);
+        setStatus('error');
+        setMessage('로그인 처리 중 오류가 발생했습니다.');
+        setTimeout(() => {
+          router.push('/front/account/login');
+        }, 3000);
+      }
+    };
+
+    handleOAuthProxy();
+  }, [searchParams, router]);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-purple-50 via-blue-50 to-indigo-100">
+      <div className="bg-white p-8 rounded-xl shadow-lg max-w-md w-full mx-4">
+        <div className="text-center">
+          {status === 'loading' && (
+            <>
+              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-main-color mx-auto mb-4"></div>
+              <h2 className="text-xl font-semibold text-gray-800 mb-2">
+                OAuth2 프록시 처리 중...
+              </h2>
+              <p className="text-gray-600">잠시만 기다려주세요.</p>
+            </>
+          )}
+
+          {status === 'processing' && (
+            <>
+              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-500 mx-auto mb-4"></div>
+              <h2 className="text-xl font-semibold text-gray-800 mb-2">
+                OAuth2 콜백 처리 중...
+              </h2>
+              <p className="text-gray-600">{message}</p>
+            </>
+          )}
+
+          {status === 'success' && (
+            <>
+              <div className="text-green-500 mb-4">
+                <svg
+                  className="w-16 h-16 mx-auto"
+                  fill="currentColor"
+                  viewBox="0 0 20 20"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+              </div>
+              <h2 className="text-xl font-semibold text-gray-800 mb-2">
+                로그인 성공!
+              </h2>
+              <p className="text-gray-600">{message}</p>
+            </>
+          )}
+
+          {status === 'error' && (
+            <>
+              <div className="text-red-500 mb-4">
+                <svg
+                  className="w-16 h-16 mx-auto"
+                  fill="currentColor"
+                  viewBox="0 0 20 20"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+              </div>
+              <h2 className="text-xl font-semibold text-gray-800 mb-2">
+                처리 실패
+              </h2>
+              <p className="text-gray-600">{message}</p>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function OAuthProxy() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-purple-50 via-blue-50 to-indigo-100">
+          <div className="bg-white p-8 rounded-xl shadow-lg max-w-md w-full mx-4">
+            <div className="text-center">
+              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-purple-500 mx-auto mb-4"></div>
+              <h2 className="text-xl font-semibold text-gray-800 mb-2">
+                페이지 로딩 중...
+              </h2>
+              <p className="text-gray-600">잠시만 기다려주세요.</p>
+            </div>
+          </div>
+        </div>
+      }
+    >
+      <OAuthProxyContent />
+    </Suspense>
+  );
+}

--- a/src/app/front/account/oauth-proxy/page.tsx
+++ b/src/app/front/account/oauth-proxy/page.tsx
@@ -21,7 +21,7 @@ function OAuthProxyContent() {
         const token = searchParams.get('token');
 
         if (token) {
-          console.log('OAuth2 토큰 수신 (프록시):', token);
+          console.log('OAuth2 토큰 수신 (프록시): 성공');
 
           // 토큰을 쿠키에 저장
           document.cookie = `accessToken=${token}; path=/; secure; SameSite=Lax`;

--- a/src/app/oauth2/success/page.tsx
+++ b/src/app/oauth2/success/page.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import React, { useEffect, useState, Suspense } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+function OAuthSuccessContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [status, setStatus] = useState<'loading' | 'success' | 'error'>(
+    'loading'
+  );
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    const handleOAuthSuccess = async () => {
+      try {
+        // URL 파라미터에서 토큰 추출
+        const token = searchParams.get('token');
+
+        if (token) {
+          console.log('OAuth2 토큰 수신:', token);
+
+          // 토큰을 쿠키에 저장
+          document.cookie = `accessToken=${token}; path=/; secure; SameSite=Lax`;
+
+          setStatus('success');
+          setMessage('소셜 로그인 성공! 메인 페이지로 이동합니다.');
+
+          // 잠시 후 메인 페이지로 리다이렉트
+          setTimeout(() => {
+            router.push('/front/my-home');
+          }, 1500);
+        } else {
+          console.error('토큰이 URL 파라미터에 없습니다.');
+          setStatus('error');
+          setMessage('인증 정보를 찾을 수 없습니다. 다시 시도해주세요.');
+          setTimeout(() => {
+            router.push('/front/account/login');
+          }, 3000);
+        }
+      } catch (error) {
+        console.error('OAuth 성공 처리 오류:', error);
+        setStatus('error');
+        setMessage('로그인 처리 중 오류가 발생했습니다.');
+        setTimeout(() => {
+          router.push('/front/account/login');
+        }, 3000);
+      }
+    };
+
+    handleOAuthSuccess();
+  }, [searchParams, router]);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-purple-50 via-blue-50 to-indigo-100">
+      <div className="bg-white p-8 rounded-xl shadow-lg max-w-md w-full mx-4">
+        <div className="text-center">
+          {status === 'loading' && (
+            <>
+              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-main-color mx-auto mb-4"></div>
+              <h2 className="text-xl font-semibold text-gray-800 mb-2">
+                로그인 처리 중...
+              </h2>
+              <p className="text-gray-600">잠시만 기다려주세요.</p>
+            </>
+          )}
+
+          {status === 'success' && (
+            <>
+              <div className="text-green-500 mb-4">
+                <svg
+                  className="w-16 h-16 mx-auto"
+                  fill="currentColor"
+                  viewBox="0 0 20 20"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+              </div>
+              <h2 className="text-xl font-semibold text-gray-800 mb-2">
+                로그인 성공!
+              </h2>
+              <p className="text-gray-600">{message}</p>
+            </>
+          )}
+
+          {status === 'error' && (
+            <>
+              <div className="text-red-500 mb-4">
+                <svg
+                  className="w-16 h-16 mx-auto"
+                  fill="currentColor"
+                  viewBox="0 0 20 20"
+                >
+                  <path
+                    fillRule="evenodd"
+                    d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z"
+                    clipRule="evenodd"
+                  />
+                </svg>
+              </div>
+              <h2 className="text-xl font-semibold text-gray-800 mb-2">
+                로그인 실패
+              </h2>
+              <p className="text-gray-600">{message}</p>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function OAuthSuccess() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-purple-50 via-blue-50 to-indigo-100">
+          <div className="bg-white p-8 rounded-xl shadow-lg max-w-md w-full mx-4">
+            <div className="text-center">
+              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-purple-500 mx-auto mb-4"></div>
+              <h2 className="text-xl font-semibold text-gray-800 mb-2">
+                페이지 로딩 중...
+              </h2>
+              <p className="text-gray-600">잠시만 기다려주세요.</p>
+            </div>
+          </div>
+        </div>
+      }
+    >
+      <OAuthSuccessContent />
+    </Suspense>
+  );
+}

--- a/src/app/oauth2/success/page.tsx
+++ b/src/app/oauth2/success/page.tsx
@@ -18,7 +18,7 @@ function OAuthSuccessContent() {
         const token = searchParams.get('token');
 
         if (token) {
-          console.log('OAuth2 토큰 수신:', token);
+          console.log('OAuth2 토큰 수신: 성공');
 
           // 토큰을 쿠키에 저장
           document.cookie = `accessToken=${token}; path=/; secure; SameSite=Lax`;


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolves: https://github.com/DdNnTt/Chingu-Frontend/issues/117

## 📝작업 내용
- 카카오, 구글 로그인 OAuth2 엔드포인트 연동

## 스크린샷 (선택)

## 💬리뷰 요구사항(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 새 기능
  - 구글/카카오 소셜 로그인 버튼이 각 OAuth2 인증 흐름으로 이동하도록 연결.
  - OAuth 성공 페이지 추가: URL의 token을 받아 쿠키에 저장하고 상태별(로딩/성공/실패) 안내 후 자동 이동.
  - OAuth 프록시 페이지 추가: URL token 자동 처리, 실패 시 수동 입력 유도 및 쿠키 저장 후 경로별 이동.

- 리팩터링
  - 로그인 직후의 불필요한 localStorage(tokenType, nickname) 저장 제거로 토큰 관리 일관성 강화 (쿠키 중심).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->