### PR TITLE
구글, 카카오 로그인 후 임시 페이지 스타일 수정

### DIFF
--- a/src/app/front/account/oauth-proxy/page.tsx
+++ b/src/app/front/account/oauth-proxy/page.tsx
@@ -63,7 +63,7 @@ function OAuthProxyContent() {
   }, [searchParams, router]);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-purple-50 via-blue-50 to-indigo-100">
+    <div className="flex items-center justify-center bg-gradient-to-br from-purple-50 via-blue-50 to-indigo-100">
       <div className="bg-white p-8 rounded-xl shadow-lg max-w-md w-full mx-4">
         <div className="text-center">
           {status === 'loading' && (
@@ -139,7 +139,7 @@ export default function OAuthProxy() {
   return (
     <Suspense
       fallback={
-        <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-purple-50 via-blue-50 to-indigo-100">
+        <div className="flex items-center justify-center bg-gradient-to-br from-purple-50 via-blue-50 to-indigo-100">
           <div className="bg-white p-8 rounded-xl shadow-lg max-w-md w-full mx-4">
             <div className="text-center">
               <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-purple-500 mx-auto mb-4"></div>

--- a/src/app/oauth2/success/page.tsx
+++ b/src/app/oauth2/success/page.tsx
@@ -52,7 +52,7 @@ function OAuthSuccessContent() {
   }, [searchParams, router]);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-purple-50 via-blue-50 to-indigo-100">
+    <div className="flex items-center justify-center bg-gradient-to-br from-purple-50 via-blue-50 to-indigo-100">
       <div className="bg-white p-8 rounded-xl shadow-lg max-w-md w-full mx-4">
         <div className="text-center">
           {status === 'loading' && (
@@ -118,7 +118,7 @@ export default function OAuthSuccess() {
   return (
     <Suspense
       fallback={
-        <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-purple-50 via-blue-50 to-indigo-100">
+        <div className="flex items-center justify-center bg-gradient-to-br from-purple-50 via-blue-50 to-indigo-100">
           <div className="bg-white p-8 rounded-xl shadow-lg max-w-md w-full mx-4">
             <div className="text-center">
               <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-purple-500 mx-auto mb-4"></div>


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolves: https://github.com/DdNnTt/Chingu-Frontend/issues/123

## 📝작업 내용
- 카카오, 구글 로그인 후 노출 임시 페이지 스타일 수정

## 스크린샷 (선택)

## 💬리뷰 요구사항(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 스타일
  * OAuth 프록시 및 성공 페이지의 컨테이너 높이를 콘텐츠 기준으로 조정하여, 뷰포트 전체 높이 강제를 해제하고 불필요한 여백을 줄였습니다.
  * 로딩/대기 화면 포함 외곽 래퍼의 레이아웃을 정리해 스크롤 동작과 배치가 더 자연스러워졌습니다.
  * 배경 그라디언트와 중앙 정렬 등 시각적 구성은 그대로 유지되며, 특히 짧은 콘텐츠에서 화면 하단의 빈 공간이 줄어듭니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->