### PR TITLE
친구 프로필 이동 id 변경

### DIFF
--- a/src/app/front/my-home/friend-list/page.tsx
+++ b/src/app/front/my-home/friend-list/page.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link';
 
 interface Friend {
   friendUserId: number;
+  id: string;
   nickname: string;
   name: string;
   score: number;
@@ -89,7 +90,7 @@ export default function FriendListPage() {
                 </span>
               </div>
               <Link
-                href={`/front/my-home/friend/${friend.friendUserId}`}
+                href={`/front/my-home/friend/${friend.id}`}
                 className="main-color hover:underline text-sm font-medium"
               >
                 프로필


### PR DESCRIPTION
## #️⃣연관된 이슈

- resolves: https://github.com/DdNnTt/Chingu-Frontend/issues/124

## 📝작업 내용

- 기존 친구 리스트 정보 number id 조회 -> string id 조회로 변경

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 친구 목록에서 프로필 링크가 올바른 사용자 ID를 사용하도록 수정하여 프로필 페이지 이동이 정상 동작합니다.
  - 프로필 링크 경로를 업데이트해 잘못된 식별자를 참조하던 문제를 해소했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->