### PR TITLE
fix: 비밀번호 수정 시 닉네임 유지

### DIFF
--- a/src/app/api/auth/oauth/callback/route.ts
+++ b/src/app/api/auth/oauth/callback/route.ts
@@ -47,7 +47,7 @@ export async function GET(req: NextRequest) {
 
     // 토큰을 쿠키로 설정하고 메인 페이지로 리다이렉트
     const redirectResponse = NextResponse.redirect(
-      new URL('/front/my-home', req.url)
+      new URL('/front/my-home?socialType=oauth', req.url)
     );
 
     if (data.accessToken) {
@@ -56,6 +56,14 @@ export async function GET(req: NextRequest) {
         secure: true,
         sameSite: 'lax',
         maxAge: 60 * 60 * 24 * 7, // 7일
+      });
+
+      // OAuth 로그인 시 소셜 타입 쿠키도 설정
+      redirectResponse.cookies.set('loginType', 'oauth', {
+        path: '/',
+        secure: true,
+        sameSite: 'lax',
+        maxAge: 300, // 5분
       });
     }
 

--- a/src/app/front/account/del-account/page.tsx
+++ b/src/app/front/account/del-account/page.tsx
@@ -4,7 +4,7 @@ import Button from '@/components/common/Button';
 import Input from '@/components/common/Input';
 import { useRouter } from 'next/navigation';
 import { useState, useEffect } from 'react';
-import { getCookieValue } from '@/utils/cookie';
+import { getCookieValue, deleteCookie } from '@/utils/cookie';
 
 export default function MypageDeleteAccount() {
   const router = useRouter();
@@ -21,19 +21,50 @@ export default function MypageDeleteAccount() {
       if (!token) return;
 
       try {
-        // 1. JWT 토큰에서 먼저 확인
+        // 1. URL 파라미터에서 소셜 타입 확인
+        const urlParams = new URLSearchParams(window.location.search);
+        const urlSocialType = urlParams.get('socialType');
+        if (urlSocialType) {
+          console.log('[회원 탈퇴] URL에서 소셜 타입 발견:', urlSocialType);
+          setIsSocialLogin(true);
+          return;
+        }
+
+        // 2. 쿠키에서 소셜 타입 확인
+        const storedLoginType = getCookieValue('loginType');
+        if (storedLoginType) {
+          console.log('[회원 탈퇴] 쿠키에서 소셜 타입 발견:', storedLoginType);
+          setIsSocialLogin(true);
+          // 쿠키에서 제거 (한 번만 사용)
+          deleteCookie('loginType');
+          return;
+        }
+
+        // 3. JWT 토큰에서 확인
         const payload = JSON.parse(atob(token.split('.')[1]));
         console.log('[회원 탈퇴] JWT payload:', payload);
 
-        const isSocialFromJWT =
-          payload.socialType ||
-          payload.provider ||
-          payload.auth_provider ||
-          payload.login_type;
+        // JWT에서 소셜 로그인 정보 확인
+        let isSocialFromJWT = false;
+        let socialType = '';
+
+        if (payload.socialType) {
+          isSocialFromJWT = true;
+          socialType = payload.socialType;
+        } else if (payload.provider) {
+          isSocialFromJWT = true;
+          socialType = payload.provider;
+        } else if (payload.auth_provider) {
+          isSocialFromJWT = true;
+          socialType = payload.auth_provider;
+        } else if (payload.login_type) {
+          isSocialFromJWT = true;
+          socialType = payload.login_type;
+        }
 
         if (isSocialFromJWT) {
           setIsSocialLogin(true);
-          console.log('[회원 탈퇴] JWT에서 소셜 로그인 감지:', isSocialFromJWT);
+          console.log('[회원 탈퇴] JWT에서 소셜 로그인 감지:', socialType);
           return;
         }
 

--- a/src/app/front/account/login/page.tsx
+++ b/src/app/front/account/login/page.tsx
@@ -154,17 +154,25 @@ export default function Login() {
 
   // 카카오 로그인 처리
   const handleKakaoLogin = () => {
+    // 소셜 로그인 타입을 쿠키에 저장
+    document.cookie = 'loginType=kakao; path=/; max-age=300; SameSite=Lax';
+    console.log('[카카오 로그인] 쿠키 설정 완료: loginType=kakao');
+
     const apiBaseUrl =
       process.env.NEXT_PUBLIC_API_URL || 'https://chinguchingu.kro.kr';
     // URL 끝에 슬래시가 있는지 확인하고 제거
     const cleanApiBaseUrl = apiBaseUrl.replace(/\/$/, '');
     const kakaoLoginUrl = `${cleanApiBaseUrl}/oauth2/authorization/kakao`;
 
+    console.log('[카카오 로그인] 리다이렉트 URL:', kakaoLoginUrl);
     window.location.href = kakaoLoginUrl;
   };
 
   // 구글 로그인 처리
   const handleGoogleLogin = () => {
+    // 소셜 로그인 타입을 쿠키에 저장
+    document.cookie = 'loginType=google; path=/; max-age=300; SameSite=Lax';
+
     const apiBaseUrl =
       process.env.NEXT_PUBLIC_API_URL || 'https://chinguchingu.kro.kr';
     // URL 끝에 슬래시가 있는지 확인하고 제거

--- a/src/app/front/my-page/change-pw/MypageChangePwClient.tsx.tsx
+++ b/src/app/front/my-page/change-pw/MypageChangePwClient.tsx.tsx
@@ -54,9 +54,6 @@ export default function MypageChangePw() {
           Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify({
-          nickname: 'default-nickname', // ⚠️ 비번만 수정하는 경우라도 기본값 필요
-          profilePictureUrl: '',
-          bio: '',
           currentPassword: data.currentPassword,
           newPassword: data.newPassword,
           confirmNewPassword: data.confirmPassword,
@@ -79,7 +76,10 @@ export default function MypageChangePw() {
       }
 
       setMessage('비밀번호가 성공적으로 변경되었습니다.');
-      setTimeout(() => router.push('/front/my-page'), 2000);
+      setTimeout(() => {
+        // 마이페이지로 이동하면서 새로고침 파라미터 추가
+        router.push('/front/my-page?refresh=true');
+      }, 2000);
     } catch (error) {
       console.error('[비밀번호 변경 요청 오류]', error);
       setErrorMsg('서버 오류가 발생했습니다.');

--- a/src/app/front/my-page/page.tsx
+++ b/src/app/front/my-page/page.tsx
@@ -10,7 +10,7 @@ import CheckableInput from '@/components/common/CheckableInput';
 import Input from '@/components/common/Input';
 import Button from '@/components/common/Button';
 import SocialLoginBadge from '@/components/common/SocialLoginBadge';
-import { getCookieValue } from '@/utils/cookie';
+import { getCookieValue, deleteCookie } from '@/utils/cookie';
 
 const MypageSchema = z.object({
   nickname: z.string().min(2, '닉네임은 2자 이상 입력해주세요.'),
@@ -76,6 +76,7 @@ export default function Mypage() {
     if (!token) return;
 
     const payload = decodeJwtPayload(token);
+    console.log('[마이페이지] JWT payload:', payload);
 
     if (payload?.nickname) {
       setJwtNickname(payload.nickname);
@@ -87,10 +88,37 @@ export default function Mypage() {
       setValue('nickname', payload.sub);
     }
 
-    // socialType 필드 확인 및 설정
+    // 1. URL 파라미터에서 소셜 타입 확인
+    const urlParams = new URLSearchParams(window.location.search);
+    const urlSocialType = urlParams.get('socialType');
+    console.log('[마이페이지] URL 파라미터 확인:', urlSocialType);
+    if (urlSocialType) {
+      console.log('[마이페이지] URL에서 소셜 타입 발견:', urlSocialType);
+      setSocialType(urlSocialType);
+      // URL 파라미터 제거
+      const newUrl = window.location.pathname;
+      window.history.replaceState({}, document.title, newUrl);
+      return;
+    }
+
+    // 2. 쿠키에서 소셜 타입 확인
+    console.log('[마이페이지] 모든 쿠키:', document.cookie);
+    const storedLoginType = getCookieValue('loginType');
+    console.log('[마이페이지] loginType 쿠키 값:', storedLoginType);
+    if (storedLoginType) {
+      console.log('[마이페이지] 쿠키에서 소셜 타입 발견:', storedLoginType);
+      setSocialType(storedLoginType);
+      // 쿠키에서 제거 (한 번만 사용)
+      deleteCookie('loginType');
+      return;
+    }
+
+    // 3. JWT에서 소셜 타입 확인 (기존 로직)
     if (payload?.socialType) {
+      console.log('[마이페이지] JWT에서 socialType 발견:', payload.socialType);
       setSocialType(payload.socialType);
     } else {
+      console.log('[마이페이지] JWT에서 socialType 없음, 다른 필드 확인 중...');
       // 다른 가능한 필드명들 확인
       const possibleSocialFields = [
         'social_type',
@@ -104,9 +132,12 @@ export default function Mypage() {
         'given_name',
         'family_name',
       ];
+
+      let socialTypeFound = false;
       for (const field of possibleSocialFields) {
         if (payload?.[field] && typeof payload[field] === 'string') {
           const value = payload[field] as string;
+          console.log(`[마이페이지] 필드 ${field} 값:`, value);
 
           // 카카오 관련 키워드 확인
           if (
@@ -114,23 +145,43 @@ export default function Mypage() {
             value.toLowerCase().includes('kakao.com') ||
             value.toLowerCase().includes('kakaoaccount')
           ) {
+            console.log('[마이페이지] 카카오 로그인 감지됨');
             setSocialType('kakao');
+            socialTypeFound = true;
             break;
           }
           // 구글 관련 키워드 확인
           if (value.toLowerCase().includes('google')) {
+            console.log('[마이페이지] 구글 로그인 감지됨');
             setSocialType('google');
+            socialTypeFound = true;
             break;
           }
         }
       }
+
+      if (!socialTypeFound) {
+        console.log('[마이페이지] JWT에서 소셜 로그인 정보를 찾을 수 없음');
+      }
     }
-  }, [setValue, socialType]);
+  }, [setValue]);
 
   useEffect(() => {
     const token = getCookieValue('accessToken');
 
     if (!token) return;
+
+    // refresh 파라미터 확인
+    const urlParams = new URLSearchParams(window.location.search);
+    const shouldRefresh = urlParams.get('refresh');
+    if (shouldRefresh) {
+      console.log(
+        '[마이페이지] 새로고침 파라미터 감지, 사용자 정보 강제 새로고침'
+      );
+      // URL에서 refresh 파라미터 제거
+      const newUrl = window.location.pathname;
+      window.history.replaceState({}, document.title, newUrl);
+    }
 
     const checkUploadLimit = () => {
       // SSR 환경에서 localStorage 접근 안전성 확인
@@ -184,6 +235,12 @@ export default function Mypage() {
       tokenNickname = '';
     }
 
+    console.log('[마이페이지] JWT에서 추출한 닉네임:', {
+      payloadNickname: payload?.nickname,
+      payloadSub: payload?.sub,
+      tokenNickname: tokenNickname,
+    });
+
     fetch('/api/users/mypage', {
       method: 'GET',
       headers: {
@@ -196,15 +253,50 @@ export default function Mypage() {
           router.push('/front/account/login');
           return;
         }
-        if (!res.ok) throw new Error('유저 정보 조회 실패');
+        if (!res.ok) {
+          console.error('[유저 정보 불러오기 오류] 응답 상태:', res.status);
+          throw new Error('유저 정보 조회 실패');
+        }
         return res.json();
       })
       .then((data) => {
         if (!data) return;
 
-        // API 응답의 닉네임이 없거나 비어있으면 JWT 토큰의 닉네임 사용
-        const finalNickname =
-          data.nickname || tokenNickname || jwtNickname || '';
+        console.log('[마이페이지] API 응답 데이터:', data);
+
+        // API 응답에서 socialType 확인
+        if (data.socialType) {
+          console.log('[마이페이지] API에서 socialType 발견:', data.socialType);
+          setSocialType(data.socialType);
+        } else if (data.provider) {
+          console.log('[마이페이지] API에서 provider 발견:', data.provider);
+          setSocialType(data.provider);
+        } else if (data.social_type) {
+          console.log(
+            '[마이페이지] API에서 social_type 발견:',
+            data.social_type
+          );
+          setSocialType(data.social_type);
+        }
+
+        // API 응답의 닉네임을 우선 사용, default-nickname이면 JWT sub 사용
+        let finalNickname = data.nickname || tokenNickname || jwtNickname || '';
+
+        // default-nickname이면 JWT의 sub 필드 사용
+        if (finalNickname === 'default-nickname' && payload?.sub) {
+          finalNickname = payload.sub;
+          console.log(
+            '[마이페이지] default-nickname 감지, JWT sub 사용:',
+            payload.sub
+          );
+        }
+
+        console.log('[마이페이지] 닉네임 우선순위:', {
+          apiNickname: data.nickname,
+          tokenNickname: tokenNickname,
+          jwtNickname: jwtNickname,
+          finalNickname: finalNickname,
+        });
 
         reset({
           nickname: finalNickname,
@@ -215,7 +307,41 @@ export default function Mypage() {
 
         if (data.profilePictureUrl) setImagePreview(data.profilePictureUrl);
       })
-      .catch((err) => console.error('[유저 정보 불러오기 오류]', err));
+      .catch((err) => {
+        console.error('[유저 정보 불러오기 오류]', err);
+        // API 호출 실패 시 JWT에서 닉네임 사용
+        console.log('[마이페이지] API 실패, JWT에서 닉네임 사용');
+        let finalNickname = tokenNickname || jwtNickname || '';
+
+        // default-nickname이면 JWT의 sub 필드 사용
+        if (finalNickname === 'default-nickname' && payload?.sub) {
+          finalNickname = payload.sub;
+          console.log(
+            '[마이페이지] API 실패 후 default-nickname 감지, JWT sub 사용:',
+            payload.sub
+          );
+        }
+
+        if (finalNickname) {
+          reset({
+            nickname: finalNickname,
+            name: '',
+            userId: '',
+            email: '',
+          });
+        }
+
+        // 쿠키에서 소셜 타입 재확인
+        const storedLoginType = getCookieValue('loginType');
+        if (storedLoginType) {
+          console.log(
+            '[마이페이지] API 실패 후 쿠키에서 소셜 타입 발견:',
+            storedLoginType
+          );
+          setSocialType(storedLoginType);
+          deleteCookie('loginType');
+        }
+      });
 
     return () => {
       clearTimeout(timeoutId);
@@ -472,12 +598,10 @@ export default function Mypage() {
           <div className="flex items-center gap-2">
             <h3 className="text-lg font-semibold mb-2">내 정보</h3>
             <SocialLoginBadge socialType={socialType} />
-            {/* 디버깅용: socialType 상태 확인 */}
-            {!socialType && (
-              <div className="text-xs text-gray-500 bg-gray-100 px-2 py-1 rounded">
-                socialType: {socialType || 'undefined'}
-              </div>
-            )}
+            {/* socialType 상태 확인 */}
+            <div className="text-xs text-gray-500 bg-gray-100 px-2 py-1 rounded">
+              socialType: {socialType || 'undefined'}
+            </div>
           </div>
           <Button
             type="button"

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -2,3 +2,7 @@ export const getCookieValue = (name: string): string | null => {
   const match = document.cookie.match(new RegExp(`(^| )${name}=([^;]+)`));
   return match ? decodeURIComponent(match[2]) : null;
 };
+
+export const deleteCookie = (name: string): void => {
+  document.cookie = `${name}=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 소셜 로그인 유형을 URL 파라미터와 임시 쿠키로 자동 인식하여 계정 삭제/마이페이지 흐름을 간소화합니다.
  - 로그인 시(카카오/구글) 임시 로그인 유형 쿠키를 설정해 이후 화면에서 즉시 반영됩니다.
  - 마이페이지 진입 시 refresh 파라미터로 강제 새로고침을 지원합니다.
  - 마이페이지에서 소셜 상태 배지를 항상 표시하고, 닉네임을 더 안정적으로 결정합니다.
  - OAuth 콜백 후 홈으로의 리다이렉트에 소셜 유형을 포함합니다.
- 변경 사항
  - 비밀번호 변경 후 2초 뒤 마이페이지로 이동하며 데이터가 새로 고침됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->