### PR TITLE
axios baseURL 환경별 분리 및 누락된 API route 추가

### DIFF
--- a/src/app/api/messages/[messageId]/route.ts
+++ b/src/app/api/messages/[messageId]/route.ts
@@ -1,0 +1,94 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+// 쪽지 삭제 (DELETE)
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ messageId: string }> }
+) {
+  const { messageId } = await params;
+  const token = req.headers.get('authorization');
+  const API_BASE = process.env.API_BASE_URL;
+
+  if (!API_BASE) {
+    return NextResponse.json({ message: 'API 주소 누락' }, { status: 500 });
+  }
+
+  if (!messageId) {
+    return NextResponse.json({ message: 'messageId 누락' }, { status: 400 });
+  }
+
+  if (!token) {
+    return NextResponse.json(
+      { message: '인증 토큰이 필요합니다' },
+      { status: 401 }
+    );
+  }
+
+  try {
+    console.log('[쪽지 삭제 프록시] 요청 데이터:', {
+      messageId,
+      token: token ? `${token.substring(0, 20)}...` : 'null',
+      API_BASE,
+    });
+
+    const res = await fetch(`${API_BASE}/api/messages/${messageId}`, {
+      method: 'DELETE',
+      headers: {
+        Authorization: token,
+      },
+    });
+
+    console.log('[쪽지 삭제 프록시] 백엔드 응답:', {
+      status: res.status,
+      statusText: res.statusText,
+    });
+
+    const text = await res.text();
+    console.log('[쪽지 삭제 프록시] 백엔드 응답 텍스트:', text);
+
+    if (!res.ok) {
+      let errorMessage = '쪽지 삭제 실패';
+      try {
+        const errorData = JSON.parse(text);
+        errorMessage = errorData.message || errorMessage;
+      } catch {
+        errorMessage = text || errorMessage;
+      }
+      return NextResponse.json(
+        { message: errorMessage },
+        { status: res.status }
+      );
+    }
+
+    // 삭제 성공 시 빈 응답일 수 있으므로 처리
+    if (text) {
+      try {
+        const data = JSON.parse(text);
+        return NextResponse.json(data, { status: res.status });
+      } catch (parseError) {
+        console.error('[쪽지 삭제 프록시] JSON 파싱 실패:', parseError);
+        // 빈 응답이거나 JSON이 아닐 경우 성공 메시지 반환
+        return NextResponse.json(
+          { message: '쪽지가 삭제되었습니다.' },
+          { status: res.status }
+        );
+      }
+    } else {
+      return NextResponse.json(
+        { message: '쪽지가 삭제되었습니다.' },
+        { status: res.status }
+      );
+    }
+  } catch (err) {
+    console.error('[쪽지 삭제 프록시 오류]', err);
+    return NextResponse.json(
+      {
+        message: '쪽지 삭제 중 오류가 발생했습니다.',
+        error: err instanceof Error ? err.message : String(err),
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/messages/read/[messageId]/route.ts
+++ b/src/app/api/messages/read/[messageId]/route.ts
@@ -1,0 +1,148 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+// 특정 쪽지 조회 (GET)
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ messageId: string }> }
+) {
+  const { messageId } = await params;
+  const token = req.headers.get('authorization');
+  const API_BASE = process.env.API_BASE_URL;
+
+  if (!API_BASE) {
+    return NextResponse.json({ message: 'API 주소 누락' }, { status: 500 });
+  }
+
+  if (!messageId) {
+    return NextResponse.json({ message: 'messageId 누락' }, { status: 400 });
+  }
+
+  try {
+    console.log('[쪽지 조회 프록시] 요청 데이터:', {
+      messageId,
+      token: token ? `${token.substring(0, 20)}...` : 'null',
+      API_BASE,
+    });
+
+    const res = await fetch(`${API_BASE}/api/messages/read/${messageId}`, {
+      method: 'GET',
+      headers: {
+        Authorization: token ?? '',
+      },
+    });
+
+    console.log('[쪽지 조회 프록시] 백엔드 응답:', {
+      status: res.status,
+      statusText: res.statusText,
+    });
+
+    const text = await res.text();
+    console.log('[쪽지 조회 프록시] 백엔드 응답 텍스트:', text);
+
+    if (!res.ok) {
+      let errorMessage = '쪽지 조회 실패';
+      try {
+        const errorData = JSON.parse(text);
+        errorMessage = errorData.message || errorMessage;
+      } catch {
+        errorMessage = text || errorMessage;
+      }
+      return NextResponse.json(
+        { message: errorMessage },
+        { status: res.status }
+      );
+    }
+
+    try {
+      const data = JSON.parse(text);
+      return NextResponse.json(data, { status: res.status });
+    } catch (parseError) {
+      console.error('[쪽지 조회 프록시] JSON 파싱 실패:', parseError);
+      return NextResponse.json({ message: '응답 파싱 실패' }, { status: 500 });
+    }
+  } catch (err) {
+    console.error('[쪽지 조회 프록시 오류]', err);
+    return NextResponse.json(
+      {
+        message: '쪽지 조회 중 오류가 발생했습니다.',
+        error: err instanceof Error ? err.message : String(err),
+      },
+      { status: 500 }
+    );
+  }
+}
+
+// 쪽지 읽음 처리 (PATCH)
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ messageId: string }> }
+) {
+  const { messageId } = await params;
+  const token = req.headers.get('authorization');
+  const API_BASE = process.env.API_BASE_URL;
+
+  if (!API_BASE) {
+    return NextResponse.json({ message: 'API 주소 누락' }, { status: 500 });
+  }
+
+  if (!messageId) {
+    return NextResponse.json({ message: 'messageId 누락' }, { status: 400 });
+  }
+
+  try {
+    console.log('[쪽지 읽음 처리 프록시] 요청 데이터:', {
+      messageId,
+      token: token ? `${token.substring(0, 20)}...` : 'null',
+      API_BASE,
+    });
+
+    const res = await fetch(`${API_BASE}/api/messages/read/${messageId}`, {
+      method: 'PATCH',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: token ?? '',
+      },
+    });
+
+    console.log('[쪽지 읽음 처리 프록시] 백엔드 응답:', {
+      status: res.status,
+      statusText: res.statusText,
+    });
+
+    const text = await res.text();
+    console.log('[쪽지 읽음 처리 프록시] 백엔드 응답 텍스트:', text);
+
+    if (!res.ok) {
+      let errorMessage = '쪽지 읽음 처리 실패';
+      try {
+        const errorData = JSON.parse(text);
+        errorMessage = errorData.message || errorMessage;
+      } catch {
+        errorMessage = text || errorMessage;
+      }
+      return NextResponse.json(
+        { message: errorMessage },
+        { status: res.status }
+      );
+    }
+
+    try {
+      const data = JSON.parse(text);
+      return NextResponse.json(data, { status: res.status });
+    } catch (parseError) {
+      console.error('[쪽지 읽음 처리 프록시] JSON 파싱 실패:', parseError);
+      return NextResponse.json({ message: '응답 파싱 실패' }, { status: 500 });
+    }
+  } catch (err) {
+    console.error('[쪽지 읽음 처리 프록시 오류]', err);
+    return NextResponse.json(
+      {
+        message: '쪽지 읽음 처리 중 오류가 발생했습니다.',
+        error: err instanceof Error ? err.message : String(err),
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/messages/read/all/route.ts
+++ b/src/app/api/messages/read/all/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+// 받은 쪽지 전체 조회 (GET)
+export async function GET(req: NextRequest) {
+  const token = req.headers.get('authorization');
+  const API_BASE = process.env.API_BASE_URL;
+
+  if (!API_BASE) {
+    return NextResponse.json({ message: 'API 주소 누락' }, { status: 500 });
+  }
+
+  try {
+    console.log('[받은 쪽지 전체 조회 프록시] 요청 데이터:', {
+      token: token ? `${token.substring(0, 20)}...` : 'null',
+      API_BASE,
+    });
+
+    const res = await fetch(`${API_BASE}/api/messages/read/all`, {
+      method: 'GET',
+      headers: {
+        Authorization: token ?? '',
+      },
+    });
+
+    console.log('[받은 쪽지 전체 조회 프록시] 백엔드 응답:', {
+      status: res.status,
+      statusText: res.statusText,
+    });
+
+    const text = await res.text();
+    console.log('[받은 쪽지 전체 조회 프록시] 백엔드 응답 텍스트:', text);
+
+    if (!res.ok) {
+      let errorMessage = '받은 쪽지 조회 실패';
+      try {
+        const errorData = JSON.parse(text);
+        errorMessage = errorData.message || errorMessage;
+      } catch {
+        errorMessage = text || errorMessage;
+      }
+      return NextResponse.json(
+        { message: errorMessage },
+        { status: res.status }
+      );
+    }
+
+    try {
+      const data = JSON.parse(text);
+      return NextResponse.json(data, { status: res.status });
+    } catch (parseError) {
+      console.error('[받은 쪽지 전체 조회 프록시] JSON 파싱 실패:', parseError);
+      return NextResponse.json({ message: '응답 파싱 실패' }, { status: 500 });
+    }
+  } catch (err) {
+    console.error('[받은 쪽지 전체 조회 프록시 오류]', err);
+    return NextResponse.json(
+      {
+        message: '받은 쪽지 조회 중 오류가 발생했습니다.',
+        error: err instanceof Error ? err.message : String(err),
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/messages/send/route.ts
+++ b/src/app/api/messages/send/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+// 쪽지 보내기 (POST)
+export async function POST(req: NextRequest) {
+  const token = req.headers.get('authorization');
+  const API_BASE = process.env.API_BASE_URL;
+
+  if (!API_BASE) {
+    return NextResponse.json({ message: 'API 주소 누락' }, { status: 500 });
+  }
+
+  if (!token) {
+    return NextResponse.json(
+      { message: '인증 토큰이 필요합니다' },
+      { status: 401 }
+    );
+  }
+
+  try {
+    const body = await req.json();
+
+    console.log('[쪽지 보내기 프록시] 요청 데이터:', {
+      body,
+      token: token ? `${token.substring(0, 20)}...` : 'null',
+      API_BASE,
+    });
+
+    const res = await fetch(`${API_BASE}/api/messages/send`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: token,
+      },
+      body: JSON.stringify(body),
+    });
+
+    console.log('[쪽지 보내기 프록시] 백엔드 응답:', {
+      status: res.status,
+      statusText: res.statusText,
+    });
+
+    const text = await res.text();
+    console.log('[쪽지 보내기 프록시] 백엔드 응답 텍스트:', text);
+
+    if (!res.ok) {
+      let errorMessage = '쪽지 보내기 실패';
+      try {
+        const errorData = JSON.parse(text);
+        errorMessage = errorData.message || errorMessage;
+      } catch {
+        errorMessage = text || errorMessage;
+      }
+      return NextResponse.json(
+        { message: errorMessage },
+        { status: res.status }
+      );
+    }
+
+    try {
+      const data = JSON.parse(text);
+      return NextResponse.json(data, { status: res.status });
+    } catch (parseError) {
+      console.error('[쪽지 보내기 프록시] JSON 파싱 실패:', parseError);
+      return NextResponse.json({ message: '응답 파싱 실패' }, { status: 500 });
+    }
+  } catch (err) {
+    console.error('[쪽지 보내기 프록시 오류]', err);
+    return NextResponse.json(
+      {
+        message: '쪽지 보내기 중 오류가 발생했습니다.',
+        error: err instanceof Error ? err.message : String(err),
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/messages/sent/route.ts
+++ b/src/app/api/messages/sent/route.ts
@@ -1,0 +1,66 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+// 보낸 쪽지 전체 조회 (GET)
+export async function GET(req: NextRequest) {
+  const token = req.headers.get('authorization');
+  const API_BASE = process.env.API_BASE_URL;
+
+  if (!API_BASE) {
+    return NextResponse.json({ message: 'API 주소 누락' }, { status: 500 });
+  }
+
+  try {
+    console.log('[보낸 쪽지 조회 프록시] 요청 데이터:', {
+      token: token ? `${token.substring(0, 20)}...` : 'null',
+      API_BASE,
+    });
+
+    const res = await fetch(`${API_BASE}/api/messages/sent`, {
+      method: 'GET',
+      headers: {
+        Authorization: token ?? '',
+      },
+    });
+
+    console.log('[보낸 쪽지 조회 프록시] 백엔드 응답:', {
+      status: res.status,
+      statusText: res.statusText,
+    });
+
+    const text = await res.text();
+    console.log('[보낸 쪽지 조회 프록시] 백엔드 응답 텍스트:', text);
+
+    if (!res.ok) {
+      let errorMessage = '보낸 쪽지 조회 실패';
+      try {
+        const errorData = JSON.parse(text);
+        errorMessage = errorData.message || errorMessage;
+      } catch {
+        errorMessage = text || errorMessage;
+      }
+      return NextResponse.json(
+        { message: errorMessage },
+        { status: res.status }
+      );
+    }
+
+    try {
+      const data = JSON.parse(text);
+      return NextResponse.json(data, { status: res.status });
+    } catch (parseError) {
+      console.error('[보낸 쪽지 조회 프록시] JSON 파싱 실패:', parseError);
+      return NextResponse.json({ message: '응답 파싱 실패' }, { status: 500 });
+    }
+  } catch (err) {
+    console.error('[보낸 쪽지 조회 프록시 오류]', err);
+    return NextResponse.json(
+      {
+        message: '보낸 쪽지 조회 중 오류가 발생했습니다.',
+        error: err instanceof Error ? err.message : String(err),
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/quizzes/my-quizzes/route.ts
+++ b/src/app/api/quizzes/my-quizzes/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+// 내가 만든 퀴즈 목록 조회 (GET)
+export async function GET(req: NextRequest) {
+  const token = req.headers.get('authorization');
+  const API_BASE = process.env.API_BASE_URL;
+
+  if (!API_BASE) {
+    return NextResponse.json({ message: 'API 주소 누락' }, { status: 500 });
+  }
+
+  try {
+    const res = await fetch(`${API_BASE}/api/quizzes/my-quizzes`, {
+      method: 'GET',
+      headers: {
+        Authorization: token ?? '',
+      },
+    });
+
+    const text = await res.text();
+
+    if (!res.ok) {
+      return NextResponse.json(
+        { message: text || '내 퀴즈 조회 실패' },
+        { status: res.status }
+      );
+    }
+
+    try {
+      const data = JSON.parse(text);
+      return NextResponse.json(data, { status: res.status });
+    } catch {
+      return NextResponse.json({ message: '응답 파싱 실패' }, { status: 500 });
+    }
+  } catch (err) {
+    return NextResponse.json(
+      {
+        message: '내 퀴즈 조회 중 오류',
+        error: err instanceof Error ? err.message : String(err),
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/schedules/[scheduleId]/route.ts
+++ b/src/app/api/schedules/[scheduleId]/route.ts
@@ -1,0 +1,111 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+// 일정 수정 (PUT)
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: Promise<{ scheduleId: string }> }
+) {
+  const { scheduleId } = await params;
+  const token = req.headers.get('authorization');
+  const API_BASE = process.env.API_BASE_URL;
+
+  if (!API_BASE) {
+    return NextResponse.json({ message: 'API 주소 누락' }, { status: 500 });
+  }
+
+  try {
+    const body = await req.json();
+
+    const res = await fetch(`${API_BASE}/api/schedules/${scheduleId}`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: token ?? '',
+      },
+      body: JSON.stringify(body),
+    });
+
+    const text = await res.text();
+
+    if (!res.ok) {
+      return NextResponse.json(
+        { message: text || '일정 수정 실패' },
+        { status: res.status }
+      );
+    }
+
+    try {
+      const data = JSON.parse(text);
+      return NextResponse.json(data, { status: res.status });
+    } catch {
+      return NextResponse.json({ message: '응답 파싱 실패' }, { status: 500 });
+    }
+  } catch (err) {
+    return NextResponse.json(
+      {
+        message: '일정 수정 중 오류',
+        error: err instanceof Error ? err.message : String(err),
+      },
+      { status: 500 }
+    );
+  }
+}
+
+// 일정 삭제 (DELETE)
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ scheduleId: string }> }
+) {
+  const { scheduleId } = await params;
+  const token = req.headers.get('authorization');
+  const API_BASE = process.env.API_BASE_URL;
+
+  if (!API_BASE) {
+    return NextResponse.json({ message: 'API 주소 누락' }, { status: 500 });
+  }
+
+  try {
+    const res = await fetch(`${API_BASE}/api/schedules/${scheduleId}`, {
+      method: 'DELETE',
+      headers: {
+        Authorization: token ?? '',
+      },
+    });
+
+    const text = await res.text();
+
+    if (!res.ok) {
+      return NextResponse.json(
+        { message: text || '일정 삭제 실패' },
+        { status: res.status }
+      );
+    }
+
+    if (text) {
+      try {
+        const data = JSON.parse(text);
+        return NextResponse.json(data, { status: res.status });
+      } catch {
+        return NextResponse.json(
+          { message: '일정이 삭제되었습니다.' },
+          { status: res.status }
+        );
+      }
+    }
+
+    return NextResponse.json(
+      { message: '일정이 삭제되었습니다.' },
+      { status: res.status }
+    );
+  } catch (err) {
+    return NextResponse.json(
+      {
+        message: '일정 삭제 중 오류',
+        error: err instanceof Error ? err.message : String(err),
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/schedules/route.ts
+++ b/src/app/api/schedules/route.ts
@@ -1,0 +1,93 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+export const dynamic = 'force-dynamic';
+
+// 일정 목록 조회 (GET)
+export async function GET(req: NextRequest) {
+  const token = req.headers.get('authorization');
+  const API_BASE = process.env.API_BASE_URL;
+
+  if (!API_BASE) {
+    return NextResponse.json({ message: 'API 주소 누락' }, { status: 500 });
+  }
+
+  try {
+    const res = await fetch(`${API_BASE}/api/schedules`, {
+      method: 'GET',
+      headers: {
+        Authorization: token ?? '',
+      },
+    });
+
+    const text = await res.text();
+
+    if (!res.ok) {
+      return NextResponse.json(
+        { message: text || '일정 조회 실패' },
+        { status: res.status }
+      );
+    }
+
+    try {
+      const data = JSON.parse(text);
+      return NextResponse.json(data, { status: res.status });
+    } catch {
+      return NextResponse.json({ message: '응답 파싱 실패' }, { status: 500 });
+    }
+  } catch (err) {
+    return NextResponse.json(
+      {
+        message: '일정 조회 중 오류',
+        error: err instanceof Error ? err.message : String(err),
+      },
+      { status: 500 }
+    );
+  }
+}
+
+// 일정 생성 (POST)
+export async function POST(req: NextRequest) {
+  const token = req.headers.get('authorization');
+  const API_BASE = process.env.API_BASE_URL;
+
+  if (!API_BASE) {
+    return NextResponse.json({ message: 'API 주소 누락' }, { status: 500 });
+  }
+
+  try {
+    const body = await req.json();
+
+    const res = await fetch(`${API_BASE}/api/schedules`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: token ?? '',
+      },
+      body: JSON.stringify(body),
+    });
+
+    const text = await res.text();
+
+    if (!res.ok) {
+      return NextResponse.json(
+        { message: text || '일정 생성 실패' },
+        { status: res.status }
+      );
+    }
+
+    try {
+      const data = JSON.parse(text);
+      return NextResponse.json(data, { status: res.status });
+    } catch {
+      return NextResponse.json({ message: '응답 파싱 실패' }, { status: 500 });
+    }
+  } catch (err) {
+    return NextResponse.json(
+      {
+        message: '일정 생성 중 오류',
+        error: err instanceof Error ? err.message : String(err),
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/src/libs/axios.ts
+++ b/src/libs/axios.ts
@@ -1,8 +1,17 @@
 import axios, { InternalAxiosRequestConfig } from 'axios';
 import { getCookieValue } from '@/utils/cookie';
 
+const getBaseURL = () => {
+  // 브라우저 환경(클라이언트)에서는 baseURL 없이 상대 경로 사용
+  if (typeof window !== 'undefined') {
+    return '';
+  }
+  // 서버 환경에서는 백엔드 URL 사용
+  return process.env.API_BASE_URL || '';
+};
+
 const instance = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_API_URL,
+  baseURL: getBaseURL(),
   headers: {
     'Content-Type': 'application/json',
   },


### PR DESCRIPTION
## #️⃣연관된 이슈

- https://github.com/DdNnTt/Chingu-Frontend/issues/159

## 📝작업 내용

- axios baseURL 환경별 분리 및 누락된 API route 추가

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 쪽지 보내기, 삭제, 단건 읽기/읽음 처리, 전체 읽음, 보낸 쪽지 조회 기능을 위한 API 엔드포인트 추가
  - 내 퀴즈 목록 조회 API 추가
  - 일정 조회/생성/수정/삭제를 위한 API 추가
- Improvements
  - 서버/클라이언트 환경에 따라 기본 API 경로를 자동 선택해 요청 안정성 향상
  - 백엔드 오류 전파 및 응답 메시지 일관성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->