### PR TITLE
앨범 불러오기 무한 로딩

### DIFF
--- a/src/app/admin/group/page.tsx
+++ b/src/app/admin/group/page.tsx
@@ -164,10 +164,27 @@ export default function AdminGroup() {
         <div className="mb-6">
           <div className="relative mb-4 min-h-[40px] flex items-center justify-center">
             <button
+              type="button"
               onClick={() => router.back()}
-              className="px-4 py-3 rounded-lg transition-colors bg-gray-200 text-gray-700 absolute left-0 top-1/2 -translate-y-1/2 px-3 py-1 text-sm"
+              className="text-gray-600 hover:text-gray-800 absolute left-0 top-1/2 -translate-y-1/2"
+              aria-label="뒤로가기"
             >
-              ← 뒤로
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={2}
+                stroke="currentColor"
+                className="w-6 h-6"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18"
+                />
+              </svg>
             </button>
             <h1 className="text-2xl font-semibold text-gray-900 text-center w-full">
               그룹 관리

--- a/src/app/admin/main/page.tsx
+++ b/src/app/admin/main/page.tsx
@@ -57,10 +57,27 @@ export default function AdminMain() {
       <div className="admin-page py-4 px-4 pt-10 pb-10 mx-auto rounded-lg bg-gray-100 overflow-y-auto">
         <div className="relative mb-6 min-h-[40px] flex items-center justify-center">
           <button
+            type="button"
             onClick={() => router.back()}
-            className="px-4 py-3 rounded-lg transition-colors bg-gray-200 text-gray-700 absolute left-0 top-1/2 -translate-y-1/2 px-3 py-1 text-sm"
+            className="text-gray-600 hover:text-gray-800 absolute left-0 top-1/2 -translate-y-1/2"
+            aria-label="뒤로가기"
           >
-            ← 뒤로
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={2}
+              stroke="currentColor"
+              className="w-6 h-6"
+              aria-hidden="true"
+              focusable="false"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18"
+              />
+            </svg>
           </button>
           <h2 className="text-2xl font-semibold text-center w-full">
             관리자 페이지

--- a/src/app/admin/member/page.tsx
+++ b/src/app/admin/member/page.tsx
@@ -231,10 +231,27 @@ export default function AdminMember() {
         <div className="mb-6">
           <div className="relative mb-4 min-h-[40px] flex items-center justify-center">
             <button
+              type="button"
               onClick={() => router.back()}
-              className="px-4 py-3 rounded-lg transition-colors bg-gray-200 text-gray-700 absolute left-0 top-1/2 -translate-y-1/2 px-3 py-1 text-sm"
+              className="text-gray-600 hover:text-gray-800 absolute left-0 top-1/2 -translate-y-1/2"
+              aria-label="뒤로가기"
             >
-              ← 뒤로
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={2}
+                stroke="currentColor"
+                className="w-6 h-6"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18"
+                />
+              </svg>
             </button>
             <h1 className="text-2xl font-semibold text-center w-full">
               회원 관리

--- a/src/app/front/game/guess-me/make-quiz/page.tsx
+++ b/src/app/front/game/guess-me/make-quiz/page.tsx
@@ -110,10 +110,27 @@ export default function GameMakeQuiz() {
           {/* 뒤로가기 버튼과 타이틀 */}
           <div className="relative mb-6 min-h-[40px] flex items-center justify-center">
             <button
+              type="button"
               onClick={() => router.back()}
-              className="px-4 py-3 rounded-lg transition-colors bg-gray-200 text-gray-700 absolute left-0 top-1/2 -translate-y-1/2 px-3 py-1 text-sm"
+              className="text-gray-600 hover:text-gray-800 absolute left-0 top-1/2 -translate-y-1/2"
+              aria-label="뒤로가기"
             >
-              ← 뒤로
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth={2}
+                stroke="currentColor"
+                className="w-6 h-6"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18"
+                />
+              </svg>
             </button>
             <h1 className="text-3xl font-bold text-gray-800 text-center w-full">
               나를 맞춰봐 문제 만들기

--- a/src/app/front/game/guess-me/solve-quiz/page.tsx
+++ b/src/app/front/game/guess-me/solve-quiz/page.tsx
@@ -91,10 +91,27 @@ function MessageDetailContent() {
       <div className="my-home-page py-4 px-4 pt-20 pb-28 mx-auto rounded-lg bg-gray-100 overflow-y-auto">
         <div className="relative mb-6 min-h-[40px] flex items-center justify-center">
           <button
+            type="button"
             onClick={() => router.back()}
-            className="px-4 py-3 rounded-lg transition-colors bg-gray-200 text-gray-700 absolute left-0 top-1/2 -translate-y-1/2 px-3 py-1 text-sm"
+            className="text-gray-600 hover:text-gray-800 absolute left-0 top-1/2 -translate-y-1/2"
+            aria-label="뒤로가기"
           >
-            ← 뒤로
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={2}
+              stroke="currentColor"
+              className="w-6 h-6"
+              aria-hidden="true"
+              focusable="false"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18"
+              />
+            </svg>
           </button>
           <h1 className="text-2xl font-semibold text-center w-full">
             쪽지 상세
@@ -115,10 +132,27 @@ function MessageDetailContent() {
       <div className="my-home-page py-4 px-4 pt-20 pb-28 mx-auto rounded-lg bg-gray-100 overflow-y-auto">
         <div className="relative mb-6 min-h-[40px] flex items-center justify-center">
           <button
+            type="button"
             onClick={() => router.back()}
-            className="px-4 py-3 rounded-lg transition-colors bg-gray-200 text-gray-700 absolute left-0 top-1/2 -translate-y-1/2 px-3 py-1 text-sm"
+            className="text-gray-600 hover:text-gray-800 absolute left-0 top-1/2 -translate-y-1/2"
+            aria-label="뒤로가기"
           >
-            ← 뒤로
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={2}
+              stroke="currentColor"
+              className="w-6 h-6"
+              aria-hidden="true"
+              focusable="false"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18"
+              />
+            </svg>
           </button>
           <h1 className="text-2xl font-semibold text-center w-full">
             쪽지 상세
@@ -140,10 +174,27 @@ function MessageDetailContent() {
     <div className="my-home-page py-4 px-4 pt-20 pb-28 mx-auto rounded-lg bg-gray-100 min-h-screen">
       <div className="relative mb-6 min-h-[40px] flex items-center justify-center">
         <button
+          type="button"
           onClick={() => router.back()}
-          className="px-4 py-3 rounded-lg transition-colors bg-gray-200 text-gray-700 absolute left-0 top-1/2 -translate-y-1/2 px-3 py-1 text-sm"
+          className="text-gray-600 hover:text-gray-800 absolute left-0 top-1/2 -translate-y-1/2"
+          aria-label="뒤로가기"
         >
-          ← 뒤로
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={2}
+            stroke="currentColor"
+            className="w-6 h-6"
+            aria-hidden="true"
+            focusable="false"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18"
+            />
+          </svg>
         </button>
         <h1 className="text-2xl font-semibold text-center w-full">
           보낸 사람: {message.sender}

--- a/src/app/front/message/detail/MessageDetail.tsx
+++ b/src/app/front/message/detail/MessageDetail.tsx
@@ -113,10 +113,27 @@ export default function MessageDetail() {
       <div className="my-home-page py-4 px-4 pt-10 pb-10 mx-auto rounded-lg bg-gray-100 overflow-y-auto">
         <div className="relative mb-6 min-h-[40px] flex items-center justify-center">
           <button
+            type="button"
             onClick={() => router.back()}
-            className="px-4 py-3 rounded-lg transition-colors bg-gray-200 text-gray-700 absolute left-0 top-1/2 -translate-y-1/2 px-3 py-1 text-sm"
+            className="text-gray-600 hover:text-gray-800 absolute left-0 top-1/2 -translate-y-1/2"
+            aria-label="뒤로가기"
           >
-            ← 뒤로
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={2}
+              stroke="currentColor"
+              className="w-6 h-6"
+              aria-hidden="true"
+              focusable="false"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18"
+              />
+            </svg>
           </button>
           <h1 className="text-2xl font-semibold text-center w-full">
             쪽지 상세
@@ -137,10 +154,27 @@ export default function MessageDetail() {
       <div className="my-home-page py-4 px-4 pt-20 pb-28 mx-auto rounded-lg bg-gray-100 overflow-y-auto">
         <div className="relative mb-6 min-h-[40px] flex items-center justify-center">
           <button
+            type="button"
             onClick={() => router.back()}
-            className="px-4 py-3 rounded-lg transition-colors bg-gray-200 text-gray-700 absolute left-0 top-1/2 -translate-y-1/2 px-3 py-1 text-sm"
+            className="text-gray-600 hover:text-gray-800 absolute left-0 top-1/2 -translate-y-1/2"
+            aria-label="뒤로가기"
           >
-            ← 뒤로
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={2}
+              stroke="currentColor"
+              className="w-6 h-6"
+              aria-hidden="true"
+              focusable="false"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18"
+              />
+            </svg>
           </button>
           <h1 className="text-2xl font-semibold text-center w-full">
             쪽지 상세
@@ -162,10 +196,27 @@ export default function MessageDetail() {
     <div className="my-home-page py-4 px-4 pt-10 pb-10 mx-auto rounded-lg bg-gray-100 min-h-screen">
       <div className="relative mb-6 min-h-[40px] flex items-center justify-center">
         <button
+          type="button"
           onClick={() => router.back()}
-          className="px-4 py-3 rounded-lg transition-colors bg-gray-200 text-gray-700 absolute left-0 top-1/2 -translate-y-1/2 px-3 py-1 text-sm"
+          className="text-gray-600 hover:text-gray-800 absolute left-0 top-1/2 -translate-y-1/2"
+          aria-label="뒤로가기"
         >
-          ← 뒤로
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={2}
+            stroke="currentColor"
+            className="w-6 h-6"
+            aria-hidden="true"
+            focusable="false"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18"
+            />
+          </svg>
         </button>
         <h1 className="text-2xl font-semibold text-center w-full">
           보낸 사람: {message.sender}

--- a/src/app/front/message/list/page.tsx
+++ b/src/app/front/message/list/page.tsx
@@ -70,10 +70,27 @@ export default function MessageList() {
     <div className="my-home-page py-4 px-4 pt-10 pb-10 mx-auto rounded-lg bg-gray-100 overflow-y-auto">
       <div className="relative mb-6 min-h-[40px] flex items-center justify-center">
         <button
+          type="button"
           onClick={() => router.back()}
-          className="px-4 py-3 rounded-lg transition-colors bg-gray-200 text-gray-700 absolute left-0 top-1/2 -translate-y-1/2 px-3 py-1 text-sm"
+          className="text-gray-600 hover:text-gray-800 absolute left-0 top-1/2 -translate-y-1/2"
+          aria-label="뒤로가기"
         >
-          ← 뒤로
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={2}
+            stroke="currentColor"
+            className="w-6 h-6"
+            aria-hidden="true"
+            focusable="false"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18"
+            />
+          </svg>
         </button>
         <h2 className="text-2xl font-semibold text-center w-full">
           나의 쪽지함

--- a/src/app/front/my-home/friend-list/page.tsx
+++ b/src/app/front/my-home/friend-list/page.tsx
@@ -49,10 +49,27 @@ export default function FriendListPage() {
       {/* 뒤로가기 버튼과 타이틀 */}
       <div className="relative mb-6 min-h-[40px] flex items-center justify-center">
         <button
+          type="button"
           onClick={() => router.back()}
-          className="px-4 py-3 rounded-lg transition-colors bg-gray-200 text-gray-700 absolute left-0 top-1/2 -translate-y-1/2 px-3 py-1 text-sm"
+          className="text-gray-600 hover:text-gray-800 absolute left-0 top-1/2 -translate-y-1/2"
+          aria-label="뒤로가기"
         >
-          ← 뒤로
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={2}
+            stroke="currentColor"
+            className="w-6 h-6"
+            aria-hidden="true"
+            focusable="false"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18"
+            />
+          </svg>
         </button>
         <h2 className="text-2xl font-semibold text-center w-full">
           친구 리스트

--- a/src/app/front/my-home/friend-requests/page.tsx
+++ b/src/app/front/my-home/friend-requests/page.tsx
@@ -101,10 +101,27 @@ export default function FriendRequestsPage() {
     <div className="my-home-page py-4 px-4 pt-10 pb-10 mx-auto rounded-lg bg-gray-100 overflow-y-auto">
       <div className="relative mb-6 min-h-[40px] flex items-center justify-center">
         <button
+          type="button"
           onClick={() => router.back()}
-          className="px-4 py-3 rounded-lg transition-colors bg-gray-200 text-gray-700 absolute left-0 top-1/2 -translate-y-1/2 px-3 py-1 text-sm"
+          className="text-gray-600 hover:text-gray-800 absolute left-0 top-1/2 -translate-y-1/2"
+          aria-label="뒤로가기"
         >
-          ← 뒤로
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={2}
+            stroke="currentColor"
+            className="w-6 h-6"
+            aria-hidden="true"
+            focusable="false"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18"
+            />
+          </svg>
         </button>
         <h2 className="text-2xl font-semibold text-center w-full">
           받은 친구 요청

--- a/src/app/front/my-home/friend/[friendId]/page.tsx
+++ b/src/app/front/my-home/friend/[friendId]/page.tsx
@@ -444,14 +444,29 @@ export default function FriendDetailPage() {
   return (
     <div className="my-home-page py-4 px-4 pt-10 pb-10 mx-auto rounded-lg bg-gray-100 overflow-y-auto">
       <div className="relative mb-6 min-h-[40px] flex items-center justify-center">
-        <Button
+        <button
           type="button"
           onClick={handleGoBack}
-          variant="secondary"
-          className="absolute left-0 top-1/2 -translate-y-1/2 px-3 py-1 text-sm"
+          className="text-gray-600 hover:text-gray-800 absolute left-0 top-1/2 -translate-y-1/2"
+          aria-label="뒤로가기"
         >
-          ← 뒤로
-        </Button>
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth={2}
+            stroke="currentColor"
+            className="w-6 h-6"
+            aria-hidden="true"
+            focusable="false"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18"
+            />
+          </svg>
+        </button>
         <h2 className="text-2xl font-semibold text-center w-full">
           친구 마이 홈
         </h2>

--- a/src/app/front/my-home/group/album/detail/page.tsx
+++ b/src/app/front/my-home/group/album/detail/page.tsx
@@ -113,8 +113,6 @@ function AlbumDetailContent() {
     // 자정에 한 번만 체크
     const timeoutId = setTimeout(checkUploadLimit, timeUntilMidnight);
 
-    return () => clearTimeout(timeoutId);
-
     const fetchAlbumDetail = async () => {
       try {
         // 앨범 상세 정보 조회 - 새로운 API 엔드포인트 사용
@@ -146,6 +144,8 @@ function AlbumDetailContent() {
     };
 
     fetchAlbumDetail();
+
+    return () => clearTimeout(timeoutId);
   }, [groupId, albumId]);
 
   // 날짜 포맷팅 (표시용)
@@ -559,28 +559,33 @@ function AlbumDetailContent() {
 
   return (
     <div className="group-album-detail-page h-screen flex flex-col py-24 px-4 mx-auto rounded-lg bg-gray-100">
-      <div className="flex items-center mb-6">
-        <button
-          onClick={() => router.back()}
-          className="text-gray-600 hover:text-gray-800"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            strokeWidth={2}
-            stroke="currentColor"
-            className="w-6 h-6"
+      <div className="mb-6">
+        <div className="flex items-center mb-3">
+          <button
+            onClick={() => router.back()}
+            className="text-gray-600 hover:text-gray-800"
           >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18"
-            />
-          </svg>
-        </button>
-        <h2 className="text-2xl font-semibold text-center flex-1">앨범 상세</h2>
-        <div className="flex gap-2">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={2}
+              stroke="currentColor"
+              className="w-6 h-6"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M10.5 19.5L3 12m0 0l7.5-7.5M3 12h18"
+              />
+            </svg>
+          </button>
+          <h2 className="text-2xl font-semibold text-center flex-1">
+            앨범 상세
+          </h2>
+        </div>
+
+        <div className="flex gap-2 justify-end">
           <button
             onClick={handleEditAlbum}
             className="text-xs text-white border border-purple-200 px-3 py-1.5 rounded-lg font-medium shadow-sm hover:shadow-md hover:border-purple-300 transition-all duration-300 hover:scale-105 active:scale-95 backdrop-blur-sm"

--- a/src/app/front/my-home/group/album/detail/page.tsx
+++ b/src/app/front/my-home/group/album/detail/page.tsx
@@ -474,6 +474,7 @@ function AlbumDetailContent() {
       <div className="group-album-detail-page h-screen flex flex-col py-24 px-4 mx-auto rounded-lg bg-gray-100">
         <div className="flex items-center mb-6">
           <button
+            type="button"
             onClick={() => router.back()}
             className="text-gray-600 hover:text-gray-800"
             aria-label="뒤로가기"
@@ -485,6 +486,8 @@ function AlbumDetailContent() {
               strokeWidth={2}
               stroke="currentColor"
               className="w-6 h-6"
+              aria-hidden="true"
+              focusable="false"
             >
               <path
                 strokeLinecap="round"
@@ -513,6 +516,7 @@ function AlbumDetailContent() {
       <div className="group-album-detail-page h-screen flex flex-col py-24 px-4 mx-auto rounded-lg bg-gray-100">
         <div className="flex items-center mb-6">
           <button
+            type="button"
             onClick={() => router.back()}
             className="text-gray-600 hover:text-gray-800"
             aria-label="뒤로가기"
@@ -524,6 +528,8 @@ function AlbumDetailContent() {
               strokeWidth={2}
               stroke="currentColor"
               className="w-6 h-6"
+              aria-hidden="true"
+              focusable="false"
             >
               <path
                 strokeLinecap="round"
@@ -544,6 +550,7 @@ function AlbumDetailContent() {
             </h3>
             <p className="text-gray-600 mb-4">{error}</p>
             <button
+              type="button"
               onClick={() => router.back()}
               className="bg-[#9477ff] hover:bg-[#6845f5] text-white px-6 py-2 rounded-lg"
             >
@@ -562,8 +569,10 @@ function AlbumDetailContent() {
       <div className="mb-6">
         <div className="flex items-center mb-3">
           <button
+            type="button"
             onClick={() => router.back()}
             className="text-gray-600 hover:text-gray-800"
+            aria-label="뒤로가기"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg"
@@ -572,6 +581,8 @@ function AlbumDetailContent() {
               strokeWidth={2}
               stroke="currentColor"
               className="w-6 h-6"
+              aria-hidden="true"
+              focusable="false"
             >
               <path
                 strokeLinecap="round"


### PR DESCRIPTION
## #️⃣연관된 이슈
- resolves: https://github.com/DdNnTt/Chingu-Frontend/issues/164

## 📝작업 내용
- 앨범 불러오기 무한 로딩

## 스크린샷 (선택)

## 💬리뷰 요구사항(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 앨범 상세 페이지 헤더를 두 줄 구조로 재구성해 백 버튼, 제목, 우측 액션(편집/삭제)의 배치와 정렬이 더 명확해졌습니다.
  * 여러 화면의 뒤로가기 컨트롤을 텍스트에서 아이콘 버튼으로 변경하고 스타일을 간소화해 일관된 UI로 정리했습니다.

* **접근성 개선**
  * 뒤로가기 버튼들의 상호작용 속성과 레이블을 명시해 키보드/스크린리더 사용성이 향상되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->